### PR TITLE
Fixes school holds report

### DIFF
--- a/code/web/Drivers/CarlX.php
+++ b/code/web/Drivers/CarlX.php
@@ -1863,6 +1863,7 @@ class CarlX extends AbstractIlsDriver{
 				left join item_v i on ( t.bid = i.bid and t.holdingbranch = i.branch)
 				left join location_v l on i.location = l.locnumber
 				where ob.branchcode = '$location'
+				and t.renew = ob.branchnumber -- ensure pickup location (t.renew) is school. field will change to t.pickupbranch in CarlX 9.6.8.0
 				and t.transcode = 'R*'
 				and i.status = 'S'
 				order by 
@@ -1895,6 +1896,7 @@ EOT;
 		// consider using oci_set_prefetch to improve performance
 		// oci_set_prefetch($stid, 1000);
 		oci_execute($stid);
+		$data = array();
 		while (($row = oci_fetch_array ($stid, OCI_ASSOC+OCI_RETURN_NULLS)) != false) {
 			$data[] = $row;
 		}


### PR DESCRIPTION
https://trello.com/c/S1w3Cy0T

FWIW: Nashville will upgrade to CarlX 9.6.8 on March 16, 2021 -- at which point this change will need to change again because of changes to the CarlX table column names.