### PR TITLE
Automatically close menu links with dropdowns

### DIFF
--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -4723,17 +4723,22 @@ var AspenDiscovery = (function(){
 			}
 
 			$('#header-menu.dropdownMenu').mouseleave(function() {
-                setTimeout(function () {
-                    $('#header-menu.dropdownMenu').slideUp('slow');
-                        menuButton.removeClass('selected');
-                        menuButtonIcon.removeClass('fa-times');
-                        menuButtonIcon.addClass('fa-bars');
-                    }, 1000);
+				setTimeout(function () {
+					$('#header-menu.dropdownMenu').slideUp('slow');
+					menuButton.removeClass('selected');
+					menuButtonIcon.removeClass('fa-times');
+					menuButtonIcon.addClass('fa-bars');
+				}, 1000);
 			})
 
+			$(document).on('touchstart', function(e) {
+				$('#header-menu.dropdownMenu').slideUp('slow');
+				menuButton.removeClass('selected');
+				menuButtonIcon.removeClass('fa-times');
+				menuButtonIcon.addClass('fa-bars');
+			})
 			return false;
 		},
-
 		closeMenu: function(){
 			var headerMenu = $('#header-menu');
 			var menuButton = $('#menuToggleButton');
@@ -4755,6 +4760,7 @@ var AspenDiscovery = (function(){
 				menuSectionHeaderIcon.removeClass('fa-caret-right');
 				menuSectionHeaderIcon.addClass('fa-caret-down');
 			}
+
 			return false;
 		},
 		toggleAccountMenu: function() {
@@ -4770,30 +4776,27 @@ var AspenDiscovery = (function(){
 				accountMenu.css('top', accountMenuButtonPosition.top + accountMenuButton.outerHeight());
 				accountMenuButton.addClass('selected');
 				accountMenu.slideDown('slow');
-
 			}
 
-            $('#account-menu.dropdownMenu').mouseleave(function() {
-            setTimeout(function () {
-                    accountMenuButton.removeClass('selected');
-                    $('#account-menu.dropdownMenu').slideUp('slow');
-                }, 1000);
+			$('#account-menu.dropdownMenu').mouseleave(function() {
+				setTimeout(function () {
+					accountMenuButton.removeClass('selected');
+					$('#account-menu.dropdownMenu').slideUp('slow');
+				}, 1000);
+			})
 
-            })
-
-
+			$(document).on('touchstart', function(e) {
+				accountMenuButton.removeClass('selected');
+				$('#account-menu.dropdownMenu').slideUp('slow');
+			})
 
 			return false;
-
-
 		},
-
 		closeAccountMenu: function(){
 			var accountMenu = $('#account-menu');
 			var accountMenuButton = $('#accountMenuToggleButton');
 			accountMenu.slideUp('slow');
 			accountMenuButton.removeClass('selected');
-			$('.overlay').removeClass('open');
 		},
 		showCustomMenu: function (menuName) {
 			this.closeMenu();
@@ -4810,6 +4813,15 @@ var AspenDiscovery = (function(){
 				customMenu.slideDown('slow');
 			}
 
+			$(customMenu).mouseleave(function() {
+				setTimeout(function () {
+					$(customMenu).slideUp('slow');
+				}, 1000)
+			})
+
+			$(document).on('touchstart', function(e) {
+				$(customMenu).slideUp('slow');
+			})
 			return false;
 		},
 		formatCurrency: function(currencyValue, elementToUpdate){

--- a/code/web/interface/themes/responsive/js/aspen/base.js
+++ b/code/web/interface/themes/responsive/js/aspen/base.js
@@ -553,6 +553,13 @@ var AspenDiscovery = (function(){
 					menuButtonIcon.addClass('fa-bars');
 				}, 1000);
 			})
+
+			$(document).on('touchstart', function(e) {
+				$('#header-menu.dropdownMenu').slideUp('slow');
+				menuButton.removeClass('selected');
+				menuButtonIcon.removeClass('fa-times');
+				menuButtonIcon.addClass('fa-bars');
+			})
 			return false;
 		},
 		closeMenu: function(){
@@ -576,6 +583,7 @@ var AspenDiscovery = (function(){
 				menuSectionHeaderIcon.removeClass('fa-caret-right');
 				menuSectionHeaderIcon.addClass('fa-caret-down');
 			}
+
 			return false;
 		},
 		toggleAccountMenu: function() {
@@ -598,7 +606,11 @@ var AspenDiscovery = (function(){
 					accountMenuButton.removeClass('selected');
 					$('#account-menu.dropdownMenu').slideUp('slow');
 				}, 1000);
+			})
 
+			$(document).on('touchstart', function(e) {
+				accountMenuButton.removeClass('selected');
+				$('#account-menu.dropdownMenu').slideUp('slow');
 			})
 
 			return false;
@@ -624,6 +636,15 @@ var AspenDiscovery = (function(){
 				customMenu.slideDown('slow');
 			}
 
+			$(customMenu).mouseleave(function() {
+				setTimeout(function () {
+					$(customMenu).slideUp('slow');
+				}, 1000)
+			})
+
+			$(document).on('touchstart', function(e) {
+				$(customMenu).slideUp('slow');
+			})
 			return false;
 		},
 		formatCurrency: function(currencyValue, elementToUpdate){

--- a/code/web/release_notes/21.04.00.MD
+++ b/code/web/release_notes/21.04.00.MD
@@ -17,4 +17,5 @@
 - Translate the message of pickup location updated (Ticket 77498)
 - Update Open Archives Processing to check for properly formatted dates prior to adding the record to solr. (Ticket 78719)
 - Make format value within the format translation table not required so individual iTypes can be skipped during the indexing process.
-- For Koha when processing formats, check to see if translations for shelf locations, sub locations, and collections are blank before processing them as formats. 
+- For Koha when processing formats, check to see if translations for shelf locations, sub locations, and collections are blank before processing them as formats.
+- Menu links with dropdowns will automatically close after mouse leaves element or when another touch event is triggered (Ticket 79627)


### PR DESCRIPTION
Menu links with dropdowns will automatically close after mouse leaves element or when another touch event is triggered