### PR TITLE
Does not delete OverDrive titles following OverDrive server errors

### DIFF
--- a/code/overdrive_extract/src/com/turning_leaf_technologies/overdrive/ExtractOverDriveInfo.java
+++ b/code/overdrive_extract/src/com/turning_leaf_technologies/overdrive/ExtractOverDriveInfo.java
@@ -911,9 +911,14 @@ class ExtractOverDriveInfo {
 						}
 					} else {
 						if (tries == 2) {
-							logEntry.incErrors("Could not load product batch: response code " + productBatchInfoResponse.getResponseCode() + " - " + productBatchInfoResponse.getMessage());
-							logEntry.addNote(batchUrl);
-							errorsWhileLoadingProducts = true;
+    						if (productBatchInfoResponse.getResponseCode() == 500) {
+    							logEntry.incErrors("Could not load product batch: response code " + productBatchInfoResponse.getResponseCode() + " - " + productBatchInfoResponse.getMessage());
+    							logEntry.addNote(batchUrl);
+	    					else {
+    							logEntry.incErrors("Could not load product batch: response code " + productBatchInfoResponse.getResponseCode() + " - " + productBatchInfoResponse.getMessage());
+    							logEntry.addNote(batchUrl);
+	    						errorsWhileLoadingProducts = true;
+	    					}
 						}else{
 							//Give OverDrive a few seconds to sort itself out.
 							try {


### PR DESCRIPTION
https://ticket.bywatersolutions.com/SelfService/Update.html?id=82382

I have imitated the code that sidesteps error consequences from the CarlX export and submitted a pull request, but I'm not sure it would actually stop flagging the OverDrive product as deleted - and instead it might just stop the error from being tallied in the OverDrive indexing log