### PR TITLE
Add option to hide Log Me Out checkbox on holds popup

### DIFF
--- a/code/web/interface/themes/responsive/Record/hold-popup.tpl
+++ b/code/web/interface/themes/responsive/Record/hold-popup.tpl
@@ -165,9 +165,11 @@
 						{/foreach}
 					{/if}
 					<br>
+					{if $showLogMeOut == 1}
 					<div class="form-group">
 						<label for="autologout" class="checkbox"><input type="checkbox" name="autologout" id="autologout" {if $isOpac == true}checked="checked"{/if}> {translate text="Log me out after requesting the item." isPublicFacing=true}</label>
 					</div>
+					{/if}
 				</div>
 			</fieldset>
 		</form>

--- a/code/web/interface/themes/responsive/Record/hold-select-volume-popup.tpl
+++ b/code/web/interface/themes/responsive/Record/hold-select-volume-popup.tpl
@@ -148,9 +148,11 @@
 						{/foreach}
 					{/if}
 					<br>
+					{if $showLogMeOut == 1}
 					<div class="form-group">
 						<label for="autologout" class="checkbox"><input type="checkbox" name="autologout" id="autologout" {if $isOpac == true}checked="checked"{/if}> {translate text="Log me out after requesting the item." isPublicFacing=true}</label>
 					</div>
+					{/if}
 				</div>
 			</fieldset>
 		</form>

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -1060,6 +1060,14 @@ class Record_AJAX extends Action
 		$interface->assign('treatPrintNoticesAsPhoneNotices', $library->treatPrintNoticesAsPhoneNotices);
 		$interface->assign('allowRememberPickupLocation', $library->allowRememberPickupLocation);
 
+		$activeIP = IPAddress::getActiveIp();
+		$subnet = IPAddress::getIPAddressForIP($activeIP);
+		if ($subnet != false) {
+			$interface->assign('showLogMeOut', $subnet->showLogMeOut);
+		} else {
+			$interface->assign('showLogMeOut', 1);
+		}
+
 		$holdDisclaimers = array();
 		$patronLibrary = $user->getHomeLibrary();
 		if ($patronLibrary == null) {

--- a/code/web/sys/DBMaintenance/version_updates/22.01.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/22.01.00.php
@@ -10,6 +10,14 @@ function getUpdates22_01_00() : array
 				''
 			]
 		], //sample*/
+		'ip_lookup_showlogmeout' => [
+			'title' => 'Add Show Log Me Out option for IP Addresses',
+			'description' => 'Adds a boolean for whether the autologout checkbox on the place hold screen should appear or not for a given IP',
+			'sql' => [
+				'ALTER TABLE ip_lookup ADD COLUMN showLogMeOut tinyint AFTER isOpac DEFAULT 1',
+				'UPDATE ip_lookup SET showLogMeOut = isOpac',
+			]
+		], //add optionto hide log me out checkbox
 		'curbside_pickup_settings' => [
 			'title' => 'Add settings for Curbside Pickup',
 			'description' => 'Add settings for Curbside Pickup',

--- a/code/web/sys/IP/IPAddress.php
+++ b/code/web/sys/IP/IPAddress.php
@@ -9,6 +9,7 @@ class IPAddress extends DataObject
 	public $location;                //varchar(255)
 	public $ip;                      //varchar(255)
 	public $isOpac;                   //tinyint(1)
+	public $showLogMeOut;
 	public $blockAccess;
 	public $allowAPIAccess;
 	public $showDebuggingInformation;
@@ -39,6 +40,7 @@ class IPAddress extends DataObject
 			'location' => array('property'=>'location', 'type'=>'text', 'label'=>'Display Name', 'description'=>'Descriptive information for the IP Address for internal use'),
 			'locationid' => array('property'=>'locationid', 'type'=>'enum', 'values'=>$locationLookupList, 'label'=>'Location', 'description'=>'The Location which this IP address maps to'),
 			'isOpac' => array('property' => 'isOpac', 'type' => 'checkbox', 'label' => 'Treat as a Public OPAC', 'description' => 'This IP address will be treated as a public OPAC with autologout features turned on.', 'default' => true),
+			'showLogMeOut' => array('property' => 'showLogMeOut', 'type' => 'checkbox', 'label' => 'Show "Log me out" checkbox when placing a hold', 'description' => 'this is so freaking stupid', 'default' => true),
 			'blockAccess' => array('property' => 'blockAccess', 'type' => 'checkbox', 'label' => 'Block Access from this IP', 'description' => 'Traffic from this IP will not be allowed to use Aspen.', 'default' => false),
 			'allowAPIAccess' => array('property' => 'allowAPIAccess', 'type' => 'checkbox', 'label' => 'Allow API Access', 'description' => 'Traffic from this IP will be allowed to use Aspen APIs.', 'default' => false),
 			'showDebuggingInformation' => array('property' => 'showDebuggingInformation', 'type' => 'checkbox', 'label' => 'Show Debugging Information', 'description' => 'Traffic from this IP will have debugging information emitted for it.', 'default' => false),


### PR DESCRIPTION
On a per-IP basis, add the option to hide the autologout checkbox that
appears on the Place Holds pop-up.  Defaults to current behavior.

resubmitted with whitespace corrections and more optimal interface variable assignment location