### PR TITLE
preload total fines amount for worldpay so it's not 0

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/worldPayPayments.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/worldPayPayments.tpl
@@ -9,7 +9,7 @@
 	<input type="hidden" name="BillingPostalCode" value="{$profile->_zip}" />
 	<input type="hidden" name="BillingPhone" value="{$profile->phone}" />
 	<input type="hidden" name="BillingEmail" value="{$profile->email}" />
-	<input type="hidden" name="PaymentAmount" id="{$userId}FineAmount" value="0.00" />
+	<input type="hidden" name="PaymentAmount" id="{$userId}FineAmount" value="{$fineTotalsVal.$userId}" />
 	<input type="hidden" name="PaymentMethod" value="CreditOrDebit" />
 	<input type="hidden" name="ReturnUrl" id="{$userId}ReturnUrl" value="{$aspenUrl}/MyAccount/WorldPayCompleted?payment=" />
 	<input type="hidden" name="CancelUrl" id="{$userId}CancelUrl" value="{$aspenUrl}/MyAccount/WorldPayCancel?payment=" />


### PR DESCRIPTION
for if library has set to pay "all fines", otherwise when patron selects individual fines it will overwrite it to the appropriate amount