### PR TITLE
Browse Category Image Size

### DIFF
--- a/code/web/RecordDrivers/CourseReservesRecordDriver.php
+++ b/code/web/RecordDrivers/CourseReservesRecordDriver.php
@@ -94,8 +94,18 @@ class CourseReservesRecordDriver extends IndexRecordDriver
 		$interface->assign('summTitle', $this->getTitle());
 		$interface->assign('summAuthor', $this->getPrimaryAuthor());
 
-		$interface->assign('bookCoverUrl', $this->getBookcoverUrl('small'));
-		$interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('medium'));
+        //Get cover image size
+        global $interface;
+        $appliedTheme = $interface->getAppliedTheme();
+
+        $interface->assign('bookCoverUrl', $this->getBookcoverUrl('small'));
+
+        if ($appliedTheme != null && $appliedTheme->browseCategoryImageSize == 0) {
+            $interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('large'));
+        }
+        else {
+            $interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('medium'));
+        }
 
 		return 'RecordDrivers/CourseReserve/cover_result.tpl';
 	}

--- a/code/web/RecordDrivers/EbscoRecordDriver.php
+++ b/code/web/RecordDrivers/EbscoRecordDriver.php
@@ -167,8 +167,18 @@ class EbscoRecordDriver extends RecordInterface
 		$interface->assign('summUrl', $this->getLinkUrl());
 		$interface->assign('summTitle', $this->getTitle());
 
-		$interface->assign('bookCoverUrl', $this->getBookcoverUrl('small'));
-		$interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('medium'));
+        //Get cover image size
+        global $interface;
+        $appliedTheme = $interface->getAppliedTheme();
+
+        $interface->assign('bookCoverUrl', $this->getBookcoverUrl('small'));
+
+        if ($appliedTheme != null && $appliedTheme->browseCategoryImageSize == 0) {
+            $interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('large'));
+        }
+        else {
+            $interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('medium'));
+        }
 
 		return 'RecordDrivers/EBSCO/browse_result.tpl';
 	}

--- a/code/web/RecordDrivers/EbscohostRecordDriver.php
+++ b/code/web/RecordDrivers/EbscohostRecordDriver.php
@@ -178,9 +178,18 @@ class EbscohostRecordDriver extends RecordInterface
 		$interface->assign('summUrl', $this->getLinkUrl());
 		$interface->assign('summTitle', $this->getTitle());
 
-		$interface->assign('bookCoverUrl', $this->getBookcoverUrl('small'));
-		$interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('medium'));
+        //Get cover image size
+        global $interface;
+        $appliedTheme = $interface->getAppliedTheme();
 
+        $interface->assign('bookCoverUrl', $this->getBookcoverUrl('small'));
+
+        if ($appliedTheme != null && $appliedTheme->browseCategoryImageSize == 0) {
+            $interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('large'));
+        }
+        else {
+            $interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('medium'));
+        }
 		return 'RecordDrivers/EBSCOhost/browse_result.tpl';
 	}
 

--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -481,9 +481,21 @@ class GroupedWorkDriver extends IndexRecordDriver
 
 		//Get Rating
 		$interface->assign('ratingData', $this->getRatingData());
-		$interface->assign('bookCoverUrl', $this->getBookcoverUrl('small'));
-		$interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('medium'));
-		// Rating Settings
+
+        //Get cover image size
+        global $interface;
+        $appliedTheme = $interface->getAppliedTheme();
+
+        $interface->assign('bookCoverUrl', $this->getBookcoverUrl('small'));
+
+        if ($appliedTheme != null && $appliedTheme->browseCategoryImageSize == 0) {
+            $interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('large'));
+        }
+        else {
+            $interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('medium'));
+        }
+
+        // Rating Settings
 		global $library;
 		global $location;
 		if ($location) { // Try Location Setting

--- a/code/web/RecordDrivers/IndexRecordDriver.php
+++ b/code/web/RecordDrivers/IndexRecordDriver.php
@@ -349,8 +349,18 @@ abstract class IndexRecordDriver extends RecordInterface
 		$interface->assign('summTitle', $this->getTitle());
 		$interface->assign('summAuthor', $this->getPrimaryAuthor());
 
-		$interface->assign('bookCoverUrl', $this->getBookcoverUrl('small'));
-		$interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('medium'));
+        //Get cover image size
+        global $interface;
+        $appliedTheme = $interface->getAppliedTheme();
+
+        $interface->assign('bookCoverUrl', $this->getBookcoverUrl('small'));
+
+        if ($appliedTheme != null && $appliedTheme->browseCategoryImageSize == 0) {
+            $interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('large'));
+        }
+        else {
+            $interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('medium'));
+        }
 
 		return 'RecordDrivers/Index/browse_result.tpl';
 	}

--- a/code/web/RecordDrivers/ListsRecordDriver.php
+++ b/code/web/RecordDrivers/ListsRecordDriver.php
@@ -106,8 +106,18 @@ class ListsRecordDriver extends IndexRecordDriver
 		$interface->assign('summTitle', $this->getTitle());
 		$interface->assign('summAuthor', $this->getPrimaryAuthor());
 
-		$interface->assign('bookCoverUrl', $this->getBookcoverUrl('small'));
-		$interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('medium'));
+        //Get cover image size
+        global $interface;
+        $appliedTheme = $interface->getAppliedTheme();
+
+        $interface->assign('bookCoverUrl', $this->getBookcoverUrl('small'));
+
+        if ($appliedTheme != null && $appliedTheme->browseCategoryImageSize == 0) {
+            $interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('large'));
+        }
+        else {
+            $interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('medium'));
+        }
 
 		return 'RecordDrivers/List/cover_result.tpl';
 	}

--- a/code/web/RecordDrivers/PersonRecord.php
+++ b/code/web/RecordDrivers/PersonRecord.php
@@ -166,8 +166,18 @@ class PersonRecord extends IndexRecordDriver
 		$interface->assign('summUrl', $url);
 		$interface->assign('summTitle', $this->getName());
 
-		//Get book cover
-		$interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('medium'));
+        //Get cover image size
+        global $interface;
+        $appliedTheme = $interface->getAppliedTheme();
+
+        $interface->assign('bookCoverUrl', $this->getBookcoverUrl('small'));
+
+        if ($appliedTheme != null && $appliedTheme->browseCategoryImageSize == 0) {
+            $interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('large'));
+        }
+        else {
+            $interface->assign('bookCoverUrlMedium', $this->getBookcoverUrl('medium'));
+        }
 
 		return 'RecordDrivers/Person/browse_result.tpl';
 	}

--- a/code/web/release_notes/22.07.00.MD
+++ b/code/web/release_notes/22.07.00.MD
@@ -13,3 +13,5 @@
 ###Other Updates
 - When sorting editions, correct sorting by hold ratio (Ticket 98385)
 - When renewing selected titles or all titles, ensure the page refreshes properly if one or more titles renew successfully.  (Ticket 99786)
+- Show title in tabbed collection spotlights (Ticket 99624)
+- Set image size for browse categories to medium or large (Ticket 99625)

--- a/code/web/sys/DBMaintenance/version_updates/22.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/22.07.00.php
@@ -17,6 +17,13 @@ function getUpdates22_07_00() : array
 				"INSERT INTO modules (name, indexName, backgroundProcess,logClassPath,logClassName) VALUES ('Evolve', 'grouped_works', 'evolve_export','/sys/ILS/IlsExtractLogEntry.php', 'IlsExtractLogEntry')",
 			]
 		], //evolve_module
+        'themes_browse_category_image_size' => [
+            'title' => 'Theme - browse category image size',
+            'description' => 'Define cover image size for browse categories',
+            'sql' => [
+                "ALTER TABLE `themes` ADD COLUMN browseCategoryImageSize TINYINT(1) DEFAULT -1",
+            ]
+        ], //browse_category_image_size
 
 	];
 }

--- a/code/web/sys/Theming/Theme.php
+++ b/code/web/sys/Theming/Theme.php
@@ -275,6 +275,7 @@ class Theme extends DataObject
 	public $deselectedBrowseCategoryBorderColor;
 	public /** @noinspection PhpUnused */ $deselectedBrowseCategoryBorderColorDefault;
 	public $capitalizeBrowseCategories;
+    public $browseCategoryImageSize;
 
 	//Panel Colors
 	public $closedPanelBackgroundColor;
@@ -454,6 +455,7 @@ class Theme extends DataObject
 				'deselectedBrowseCategoryBorderColor' => ['property' => 'deselectedBrowseCategoryBorderColor', 'type' => 'color', 'label' => 'Deselected Browse Category Border Color', 'description' => 'Deselected Browse Category Border Color', 'required' => false, 'hideInLists' => true, 'default' => '#0087AB'],
 
 				'capitalizeBrowseCategories' => ['property' => 'capitalizeBrowseCategories', 'type' => 'enum', 'values'=> [-1 => 'Default', 0 => 'Maintain case', 1 => 'Force Uppercase'], 'label' => 'Capitalize Browse Categories', 'description' => 'How to treat capitalization of browse categories', 'required' => false, 'hideInLists' => true, 'default' => '-1'],
+                'browseCategoryImageSize' => ['property' => 'browseCategoryImageSize', 'type' => 'enum', 'values' => [-1 => 'Medium', 0 => 'Large'], 'label' => 'Browse Category Image Size','description' => 'The size of cover images to be displayed in browse categories', 'required' => false, 'hideInLists' => true, 'default' => '-1'],
 			]],
 
 			'badges' => ['property'=>'badgesSection', 'type' => 'section', 'label' =>'Badges', 'hideInLists' => true, 'properties' => [
@@ -1050,6 +1052,9 @@ class Theme extends DataObject
 				$interface->assign('capitalizeBrowseCategories', $theme->capitalizeBrowseCategories);
 			}
 
+            if ($interface->getVariable('browseCategoryImageSize') == null && $theme->browseCategoryImageSize != -1) {
+                $interface->assign('browseCategoryImageSize', $theme->browseCategoryImageSize);
+            }
 
 			if ($interface->getVariable('headerBottomBorderWidth') == null && $theme->headerBottomBorderWidth != null) {
 				$headerBottomBorderWidth = $theme->headerBottomBorderWidth;


### PR DESCRIPTION
Adds "Browse Category Image Size" category to themes under "Browse Categories" where the image size can be set to medium or large. Related drivers that fetch medium image size for covers were updated. OpenArchivesRecordDriver.php was not updated since only small book covers are fetched. Also updated Release notes to include updates for this and for ticket 99624 (titles in tabbed spotlights)