### PR TITLE
Hide LibCal Staff View

### DIFF
--- a/code/web/interface/themes/responsive/Springshare/event.tpl
+++ b/code/web/interface/themes/responsive/Springshare/event.tpl
@@ -53,7 +53,7 @@
 		<div class="col-sm-8">
 				{$recordDriver->getDescription()}
 		</div>
-		{if $showStaffView}
+		{if $loggedIn && (in_array('Administer Springshare LibCal Settings', $userPermissions))}
 			<div id="more-details-accordion" class="panel-group">
 				<div class="panel" id="staffPanel">
 					<a data-toggle="collapse" href="#staffPanelBody">

--- a/code/web/release_notes/22.07.00.MD
+++ b/code/web/release_notes/22.07.00.MD
@@ -15,4 +15,5 @@
 - When renewing selected titles or all titles, ensure the page refreshes properly if one or more titles renew successfully.  (Ticket 99786)
 - Show title in tabbed collection spotlights (Ticket 99624)
 - Set image size for browse categories to medium or large (Ticket 99625)
-- Correct display of solr data within staff view for grouped works. 
+- Correct display of solr data within staff view for grouped works.
+- Hide LibCal staff view unless user has Admin permissions for LibCal (Ticket 98786)


### PR DESCRIPTION
Staff view for LibCal events will be hidden for all users except those who have permissions to administer LibCal settings. Updated 22.07.00.MD release notes