### PR TITLE
Remove the setting "Show Detailed Hold Notice Information"

### DIFF
--- a/code/web/interface/themes/responsive/Record/hold-popup.tpl
+++ b/code/web/interface/themes/responsive/Record/hold-popup.tpl
@@ -27,15 +27,7 @@
 					{else}
 						{translate text="Holds allow you to request that a title be delivered to your home library." isPublicFacing=true}&nbsp;
 					{/if}
-					{if $showDetailedHoldNoticeInformation && $profile->_noticePreferenceLabel == 'Mail' && !$treatPrintNoticesAsPhoneNotices}
-						{translate text="Once the title arrives at your library you will be mailed a notification informing you that the title is ready for you." isPublicFacing=true}&nbsp;
-					{elseif $showDetailedHoldNoticeInformation && ($profile->_noticePreferenceLabel == 'Telephone' || ($profile->_noticePreferenceLabel eq 'Mail' && $treatPrintNoticesAsPhoneNotices))}
-						{translate text="Once the title arrives at your library you will receive a phone call informing you that the title is ready for you." isPublicFacing=true}&nbsp;
-					{elseif $showDetailedHoldNoticeInformation && $profile->_noticePreferenceLabel == 'Email'}
-						{translate text="Once the title arrives at your library you will be emailed a notification informing you that the title is ready for you." isPublicFacing=true}&nbsp;
-					{else}
 						{translate text="Once the title arrives at your library you will receive a notification informing you that the title is ready for you." isPublicFacing=true}&nbsp;
-					{/if}
 					{if $mustPickupAtHoldingBranch}
 						{translate text="You will then have 7 days to pick up the title at the library." isPublicFacing=true}&nbsp;
 					{else}

--- a/code/web/interface/themes/responsive/Record/hold-select-volume-popup.tpl
+++ b/code/web/interface/themes/responsive/Record/hold-select-volume-popup.tpl
@@ -20,15 +20,7 @@
 
 				<p class="alert alert-info">
 					{translate text="Holds allow you to request that a title be delivered to your home library." isPublicFacing=true}&nbsp;
-					{if $showDetailedHoldNoticeInformation && $profile->_noticePreferenceLabel == 'Mail' && !$treatPrintNoticesAsPhoneNotices}
-						{translate text="Once the title arrives at your library you will be mailed a notification informing you that the title is ready for you." isPublicFacing=true}&nbsp;
-					{elseif $showDetailedHoldNoticeInformation && ($profile->_noticePreferenceLabel == 'Telephone' || ($profile->_noticePreferenceLabel eq 'Mail' && $treatPrintNoticesAsPhoneNotices))}
-						{translate text="Once the title arrives at your library you will receive a phone call informing you that the title is ready for you." isPublicFacing=true}&nbsp;
-					{elseif $showDetailedHoldNoticeInformation && $profile->_noticePreferenceLabel == 'Email'}
-						{translate text="Once the title arrives at your library you will be emailed a notification informing you that the title is ready for you." isPublicFacing=true}&nbsp;
-					{else}
-						{translate text="Once the title arrives at your library you will receive a notification informing you that the title is ready for you." isPublicFacing=true}&nbsp;
-					{/if}
+					{translate text="Once the title arrives at your library you will receive a notification informing you that the title is ready for you." isPublicFacing=true}&nbsp;
 					{translate text="You will then have 7 days to pick up the title from your home library." isPublicFacing=true}&nbsp;
 				</p>
 

--- a/code/web/interface/themes/responsive/Record/hold-success-popup.tpl
+++ b/code/web/interface/themes/responsive/Record/hold-success-popup.tpl
@@ -4,13 +4,6 @@
 		{if $success}
 			<p class="alert alert-success">{$message}</p>
 			<div class="alert">
-				{if $showDetailedHoldNoticeInformation && $profile->_noticePreferenceLabel == 'Mail' && !$treatPrintNoticesAsPhoneNotices}
-					{translate text="Once the title arrives at your library you will be mailed a notification informing you that the title is ready for you." isPublicFacing=true}&nbsp;
-				{elseif $showDetailedHoldNoticeInformation && ($profile->_noticePreferenceLabel == 'Telephone' || ($profile->_noticePreferenceLabel eq 'Mail' && $treatPrintNoticesAsPhoneNotices))}
-					{translate text="Once the title arrives at your library you will receive a phone call informing you that the title is ready for you." isPublicFacing=true}&nbsp;
-				{elseif $showDetailedHoldNoticeInformation && $profile->_noticePreferenceLabel == 'Email'}
-					{translate text="Once the title arrives at your library you will be emailed a notification informing you that the title is ready for you." isPublicFacing=true}&nbsp;
-				{else}
 					{translate text="Once the title arrives at your library you will receive a notification informing you that the title is ready for you." isPublicFacing=true}&nbsp;
 				{/if}
 			</div>

--- a/code/web/release_notes/22.07.00.MD
+++ b/code/web/release_notes/22.07.00.MD
@@ -36,3 +36,4 @@
 - Update HTML id of the admin home menu option to admin-home-button.
 - Tracking of memory usage, cpu, and other server stats in the greenhouse.
 - Remove the setting "Show Detailed Hold Notice Information" and "Treat Print Notices as Phone Notices"
+- Remove duplicate, empty, My Favorites lists (Tickets 94565, 95636, 96203)

--- a/code/web/release_notes/22.07.00.MD
+++ b/code/web/release_notes/22.07.00.MD
@@ -34,3 +34,4 @@
 - Correct adding new Patron Types.
 - Update HTML id of the admin home menu option to admin-home-button.
 - Tracking of memory usage, cpu, and other server stats in the greenhouse.
+- Remove the setting "Show Detailed Hold Notice Information" and "Treat Print Notices as Phone Notices"

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -2262,14 +2262,7 @@ class MyAccount_AJAX extends JSON_Action
 					}
 				}
 
-				if (!$library->showDetailedHoldNoticeInformation) {
-					$notification_method = '';
-				} else {
-					$notification_method = ($user->_noticePreferenceLabel != 'Unknown') ? $user->_noticePreferenceLabel : '';
-					if ($notification_method == 'Mail' && $library->treatPrintNoticesAsPhoneNotices) {
-						$notification_method = 'Telephone';
-					}
-				}
+                $notification_method = ($user->_noticePreferenceLabel != 'Unknown') ? $user->_noticePreferenceLabel : '';
 				$interface->assign('notification_method', strtolower($notification_method));
 				$interface->assign('userId', $user->id);
 

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -467,8 +467,6 @@ class Record_AJAX extends Action
 						// when user preference isn't set, they will be shown a link to account profile. this link isn't needed if the user can not change notification preference.
 						$interface->assign('canUpdate', $canUpdateContactInfo);
 						$interface->assign('canChangeNoticePreference', $canChangeNoticePreference);
-						$interface->assign('showDetailedHoldNoticeInformation', $homeLibrary->showDetailedHoldNoticeInformation);
-						$interface->assign('treatPrintNoticesAsPhoneNotices', $homeLibrary->treatPrintNoticesAsPhoneNotices);
 						$interface->assign('profile', $patron);
 
 						//Get the grouped work for the record
@@ -1066,8 +1064,6 @@ class Record_AJAX extends Action
 
 		$interface->assign('showHoldCancelDate', $library->showHoldCancelDate);
 		$interface->assign('defaultNotNeededAfterDays', $library->defaultNotNeededAfterDays);
-		$interface->assign('showDetailedHoldNoticeInformation', $library->showDetailedHoldNoticeInformation);
-		$interface->assign('treatPrintNoticesAsPhoneNotices', $library->treatPrintNoticesAsPhoneNotices);
 		$interface->assign('allowRememberPickupLocation', $library->allowRememberPickupLocation && !$promptForHoldNotifications);
 		$interface->assign('showLogMeOut', $library->showLogMeOutAfterPlacingHolds);
 
@@ -1122,9 +1118,6 @@ class Record_AJAX extends Action
 		$interface->assign('id', $shortId);
 		$interface->assign('patronId', $patron->id);
 		if (!empty($_REQUEST['autologout'])) $interface->assign('autologout', $_REQUEST['autologout']); // carry user selection to Item Hold Form
-
-		$interface->assign('showDetailedHoldNoticeInformation', $homeLibrary->showDetailedHoldNoticeInformation);
-		$interface->assign('treatPrintNoticesAsPhoneNotices', $homeLibrary->treatPrintNoticesAsPhoneNotices);
 
 		// Need to place item level holds.
 		return array(

--- a/code/web/sys/DBMaintenance/version_updates/22.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/22.07.00.php
@@ -76,6 +76,14 @@ function getUpdates22_07_00() : array
 					UNIQUE (aspenSiteId, year, month, day)
 				) ENGINE INNODB',
 			]
-		],
+		],//greenhouse cpu and monitoring
+        'remove_detailed_hold_notice_configuration' => array(
+            'title' => 'Remove Detailed Hold Notice Configuration',
+            'description' => 'Remove Detailed Hold Notice Configuration',
+            'sql' => array(
+                "ALTER TABLE library DROP COLUMN showDetailedHoldNoticeInformation",
+                "ALTER TABLE library DROP COLUMN treatPrintNoticesAsPhoneNotices",
+            )
+        ), //remove_detailed_hold_notice_configuration
 	];
 }

--- a/code/web/sys/DBMaintenance/version_updates/22.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/22.07.00.php
@@ -85,5 +85,12 @@ function getUpdates22_07_00() : array
                 "ALTER TABLE library DROP COLUMN treatPrintNoticesAsPhoneNotices",
             )
         ), //remove_detailed_hold_notice_configuration
+        'remove_empty_MyFavorites_lists' => [
+            'title' => 'Remove Empty My Favorites Lists',
+            'description' => 'Remove empty My Favorites lists to cleanup past bug where duplicate empty My Favorites lists were created',
+            'sql' => [
+                "DELETE FROM user_list WHERE id NOT IN (SELECT l.listId FROM user_list_entry l) AND title='My Favorites'",
+            ]
+        ], //remove empty My Favorites lists
 	];
 }

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -210,8 +210,6 @@ class Library extends DataObject
 	public $preventLogin;
 	public $preventLoginMessage;
 
-	public $showDetailedHoldNoticeInformation;
-	public $treatPrintNoticesAsPhoneNotices;
 	public /** @noinspection PhpUnused */ $includeDplaResults;
 	public $showWhileYouWait;
 
@@ -617,7 +615,6 @@ class Library extends DataObject
 					'enableForgotPasswordLink'             => array('property'=>'enableForgotPasswordLink', 'type'=>'checkbox', 'label'=>'Enable Forgot Password Link', 'description'=>'Whether or not the user can click a link to reset their password.', 'hideInLists' => true, 'default' => 1, 'permissions' => ['Library ILS Connection']),
 					'showAlternateLibraryOptionsInProfile' => array('property' => 'showAlternateLibraryOptionsInProfile', 'type'=>'checkbox', 'label'=>'Allow Patrons to Update their Alternate Libraries', 'description'=>'Allow Patrons to See and Change Alternate Library Settings in the Catalog Options Tab in their profile.', 'hideInLists' => true, 'default' => 1, 'permissions' => ['Library ILS Options']),
 					'showWorkPhoneInProfile'               => array('property' => 'showWorkPhoneInProfile', 'type'=>'checkbox', 'label'=>'Show Work Phone in Profile', 'description'=>'Whether or not patrons should be able to change a secondary/work phone number in their profile.', 'hideInLists' => true, 'default' => 0, 'permissions' => ['Library ILS Connection']),
-					'treatPrintNoticesAsPhoneNotices'      => array('property' => 'treatPrintNoticesAsPhoneNotices', 'type' => 'checkbox', 'label' => 'Treat Print Notices As Phone Notices', 'description' => 'When showing detailed information about hold notices, treat print notices as if they are phone calls', 'hideInLists' => true, 'default' => 0, 'permissions' => ['Library ILS Connection']),
 					'showNoticeTypeInProfile'              => array('property' => 'showNoticeTypeInProfile', 'type'=>'checkbox', 'label'=>'Show Notice Type in Profile', 'description'=>'Whether or not patrons should be able to change how they receive notices in their profile.', 'hideInLists' => true, 'default' => 0, 'permissions' => ['Library ILS Connection']),
 					'addSMSIndicatorToPhone'               => array('property' => 'addSMSIndicatorToPhone', 'type'=>'checkbox', 'label'=>'Add SMS Indicator to Primary Phone', 'description'=>'Whether or not add ### TEXT ONLY to the user\'s primary phone number when they opt in to SMS notices.', 'hideInLists' => true, 'default' => 0, 'permissions' => ['Library ILS Connection']),
 					'maxFinesToAllowAccountUpdates'        => array('property' => 'maxFinesToAllowAccountUpdates', 'type'=>'currency', 'displayFormat'=>'%0.2f', 'label'=>'Maximum Fine Amount to Allow Account Updates', 'description'=>'The maximum amount that a patron can owe and still update their account. Any value <= 0 will disable this functionality.', 'hideInLists' => true, 'default' => 10, 'permissions' => ['Library ILS Options'])
@@ -640,7 +637,6 @@ class Library extends DataObject
 					'allowFreezeHolds'                  => array('property'=>'allowFreezeHolds', 'type'=>'checkbox', 'label'=>'Allow Freezing Holds', 'description'=>'Whether or not the user can freeze their holds.', 'hideInLists' => true, 'default' => 1),
 					'maxDaysToFreeze'                   => array('property'=>'maxDaysToFreeze', 'type'=>'integer', 'label'=>'Max Days to Freeze Holds', 'description'=>'Number of days that a user can suspend a hold for. Use -1 for no limit.', 'hideInLists' => true, 'default' => 365),
 					'defaultNotNeededAfterDays'         => array('property'=>'defaultNotNeededAfterDays', 'type'=>'integer', 'label'=>'Default Not Needed After Days', 'description'=>'Number of days to use for not needed after date by default. Use -1 for no default.', 'hideInLists' => true,),
-					'showDetailedHoldNoticeInformation' => array('property' => 'showDetailedHoldNoticeInformation', 'type' => 'checkbox', 'label' => 'Show Detailed Hold Notice Information', 'description' => 'Whether or not the user should be presented with detailed hold notification information, i.e. you will receive an email/phone call to xxx when the hold is available', 'hideInLists' => true, 'default' => 1, 'permissions' => ['Library ILS Connection']),
 					'inSystemPickupsOnly'               => array('property'=>'inSystemPickupsOnly', 'type'=>'checkbox', 'label'=>'In System Pickups Only', 'description'=>'Restrict pickup locations to only locations within this library system.', 'hideInLists' => true, 'default' => true, 'permissions' => ['Library ILS Connection']),
 					'validPickupSystems'                => array('property'=>'validPickupSystems', 'type'=>'text', 'label'=>'Valid Pickup Library Systems', 'description'=>'Additional Library Systems that can be used as pickup locations if the &quot;In System Pickups Only&quot; is on. List the libraries\' subdomains separated by pipes |', 'size'=>'20', 'hideInLists' => true, 'permissions' => ['Library ILS Connection']),
 					'holdDisclaimer'                    => array('property'=>'holdDisclaimer', 'type'=>'textarea', 'label'=>'Hold Disclaimer', 'description'=>'A disclaimer to display to patrons when they are placing a hold on items letting them know that their information may be available to other libraries.  Leave blank to not show a disclaimer.', 'hideInLists' => true,),
@@ -1020,7 +1016,6 @@ class Library extends DataObject
 		}
 		if ($ils == 'Koha') {
 			unset($structure['ilsSection']['properties']['userProfileSection']['properties']['showWorkPhoneInProfile']);
-			unset($structure['ilsSection']['properties']['userProfileSection']['properties']['treatPrintNoticesAsPhoneNotices']);
 			unset($structure['ilsSection']['properties']['userProfileSection']['properties']['showNoticeTypeInProfile']);
 			unset($structure['ilsSection']['properties']['userProfileSection']['properties']['addSMSIndicatorToPhone']);
 			unset($structure['ilsSection']['properties']['userProfileSection']['properties']['maxFinesToAllowAccountUpdates']);
@@ -1315,7 +1310,6 @@ class Library extends DataObject
 		$ils = $configArray['Catalog']['ils'];
 		if ($ils == 'Koha') {
 			$this->showWorkPhoneInProfile = 0;
-			$this->treatPrintNoticesAsPhoneNotices = 0;
 			$this->showNoticeTypeInProfile = 0;
 			$this->addSMSIndicatorToPhone = 0;
 		}


### PR DESCRIPTION
Removed "Show Detailed Hold Notice Information" setting as well as "treatPrintNoticesAsPhoneNotices".  Updated release notes