### PR TITLE
Update hold-success-popup.tpl

### DIFF
--- a/code/web/interface/themes/responsive/Record/hold-success-popup.tpl
+++ b/code/web/interface/themes/responsive/Record/hold-success-popup.tpl
@@ -5,7 +5,6 @@
 			<p class="alert alert-success">{$message}</p>
 			<div class="alert">
 					{translate text="Once the title arrives at your library you will receive a notification informing you that the title is ready for you." isPublicFacing=true}&nbsp;
-				{/if}
 			</div>
 
 			{if count($whileYouWaitTitles) > 0}


### PR DESCRIPTION
Getting rid of a stray {/if} I left behind when removing detailed hold notice info