### PR TITLE
Display browse images on grid or masonry

### DIFF
--- a/code/web/interface/themes/responsive/theme.css.tpl
+++ b/code/web/interface/themes/responsive/theme.css.tpl
@@ -217,6 +217,49 @@ body .container, #home-page-browse-content{ldelim}
 {rdelim}
 {/if}
 
+{if !empty($browseImageLayout)}
+#home-page-browse-results .grid-col{ldelim}
+    display: inline-grid;
+    grid-auto-rows: 1fr;
+{rdelim}
+
+@media (max-width: 479px){ldelim}
+    #home-page-browse-results .grid-col--3{ldelim}
+        display: none;
+    {rdelim}
+{rdelim}
+
+@media (max-width: 991px){ldelim}
+    #home-page-browse-results .grid-col--4{ldelim}
+        display: none;
+    {rdelim}
+{rdelim}
+
+@media (max-width: 1199px){ldelim}
+#home-page-browse-results .grid-col--5{ldelim}
+    display: none;
+    {rdelim}
+{rdelim}
+
+@media (max-width: 1199px){ldelim}
+#home-page-browse-results .grid-col--6{ldelim}
+    display: none;
+    {rdelim}
+{rdelim}
+
+#home-page-browse-results .browse-thumbnail{ldelim}
+    display: inline-flex;
+    flex-wrap:wrap;
+    justify-content: center;
+    align-items: flex-end;
+    {if !empty($browseCategoryImageSize)}
+    max-height: 250px;
+    {else}
+    max-height: 350px;
+    {/if}
+{rdelim}
+{/if}
+
 {if !empty($buttonRadius)}
 .btn{ldelim}
     border-radius: {$buttonRadius};

--- a/code/web/release_notes/22.07.00.MD
+++ b/code/web/release_notes/22.07.00.MD
@@ -38,3 +38,4 @@
 - Tracking of memory usage, cpu, and other server stats in the greenhouse.
 - Remove the setting "Show Detailed Hold Notice Information" and "Treat Print Notices as Phone Notices"
 - Remove duplicate, empty, My Favorites lists (Tickets 94565, 95636, 96203)
+- Set layout of browse category covers to grid or masonry layout

--- a/code/web/sys/DBMaintenance/version_updates/22.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/22.07.00.php
@@ -92,5 +92,12 @@ function getUpdates22_07_00() : array
                 "DELETE FROM user_list WHERE id NOT IN (SELECT l.listId FROM user_list_entry l) AND title='My Favorites'",
             ]
         ], //remove empty My Favorites lists
+        'themes_browse_image_layout' => [
+            'title' => 'Theme - browse image layout',
+            'description' => 'Choose layout of cover images for browse categories (masonry or grid)',
+            'sql' => [
+                "ALTER TABLE `themes` ADD COLUMN browseImageLayout TINYINT(1) DEFAULT -1",
+            ]
+        ], //browse image layout theme
 	];
 }

--- a/code/web/sys/Theming/Theme.php
+++ b/code/web/sys/Theming/Theme.php
@@ -276,6 +276,7 @@ class Theme extends DataObject
 	public /** @noinspection PhpUnused */ $deselectedBrowseCategoryBorderColorDefault;
 	public $capitalizeBrowseCategories;
     public $browseCategoryImageSize;
+    public $browseImageLayout;
 
 	//Panel Colors
 	public $closedPanelBackgroundColor;
@@ -456,6 +457,7 @@ class Theme extends DataObject
 
 				'capitalizeBrowseCategories' => ['property' => 'capitalizeBrowseCategories', 'type' => 'enum', 'values'=> [-1 => 'Default', 0 => 'Maintain case', 1 => 'Force Uppercase'], 'label' => 'Capitalize Browse Categories', 'description' => 'How to treat capitalization of browse categories', 'required' => false, 'hideInLists' => true, 'default' => '-1'],
                 'browseCategoryImageSize' => ['property' => 'browseCategoryImageSize', 'type' => 'enum', 'values' => [-1 => 'Medium', 0 => 'Large'], 'label' => 'Browse Category Image Size','description' => 'The size of cover images to be displayed in browse categories', 'required' => false, 'hideInLists' => true, 'default' => '-1'],
+                'browseImageLayout' => ['property' => 'browseImageLayout', 'type' => 'enum', 'values' => [0 => 'Masonry', 1 => 'Grid'], 'label' => 'Browse Image Layout', 'description' => 'The layout of cover images in browse categories', 'required' => false, 'hidInLists' => true, 'default' => '0'],
 			]],
 
 			'badges' => ['property'=>'badgesSection', 'type' => 'section', 'label' =>'Badges', 'hideInLists' => true, 'properties' => [
@@ -1054,6 +1056,10 @@ class Theme extends DataObject
 
             if ($interface->getVariable('browseCategoryImageSize') == null && $theme->browseCategoryImageSize != -1) {
                 $interface->assign('browseCategoryImageSize', $theme->browseCategoryImageSize);
+            }
+
+            if ($interface->getVariable('browseImageLayout') == null && $theme->browseImageLayout != -1) {
+                $interface->assign('browseImageLayout', $theme->browseImageLayout);
             }
 
 			if ($interface->getVariable('headerBottomBorderWidth') == null && $theme->headerBottomBorderWidth != null) {


### PR DESCRIPTION
Give admins option to display browse category cover images on a grid or in masonry (default). The setting will live in Themes->Browse Categories. Also updated release notes.