### PR TITLE
Hide border for no ratings grid display in browse

### DIFF
--- a/code/web/interface/themes/responsive/Search/home.tpl
+++ b/code/web/interface/themes/responsive/Search/home.tpl
@@ -65,7 +65,7 @@
 				</div>
 			</div>
 
-			<div id="home-page-browse-results">
+			<div id="home-page-browse-results" {if !$showRatings}class="HideBorder"{/if}>
 				<div class="grid">
 					<!-- columns -->
 					<div class="grid-col grid-col--1"></div>

--- a/code/web/interface/themes/responsive/theme.css.tpl
+++ b/code/web/interface/themes/responsive/theme.css.tpl
@@ -247,6 +247,11 @@ body .container, #home-page-browse-content{ldelim}
     {rdelim}
 {rdelim}
 
+#home-page-browse-results.HideBorder .browse-thumbnail{ldelim}
+    border: none;
+    align-items: center;
+{rdelim}
+
 #home-page-browse-results .browse-thumbnail{ldelim}
     display: inline-flex;
     flex-wrap:wrap;


### PR DESCRIPTION
Border round browse thumbnails is hidden if ratings are turned off and grid display is being used. Items are also centered in this case