### PR TITLE
EBSCOhost vs EDS 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,8 @@ sites/morgan.localhost/conf/config.ini
 sites/morgan.localhost/conf/config.pwd.ini.template
 sites/morgan.localhost/httpd-morgan.localhost.conf
 sites/morgan.localhost/morgan.localhost.bat
+.idea/scopes/_less_files.xml
+sites/kodidev.localhost/conf/config.cron.ini
+sites/kodidev.localhost/conf/config.ini
+sites/kodidev.localhost/httpd-kodidev.localhost.conf
+sites/kodidev.localhost/kodidev.localhost.bat

--- a/code/web/Drivers/marmot_inc/SearchSources.php
+++ b/code/web/Drivers/marmot_inc/SearchSources.php
@@ -189,7 +189,7 @@ class SearchSources{
 			);
 		}
 
-		if ($searchEbscohost){
+		else if ($searchEbscohost){
 			$searchOptions['ebscohost'] = array(
 				'name' => 'Articles & Databases',
 				'description' => 'EBSCOhost - Articles and Database',

--- a/code/web/release_notes/22.08.00.MD
+++ b/code/web/release_notes/22.08.00.MD
@@ -26,6 +26,9 @@
 ###OverDrive Updates
 - Default allow large deletes on. 
 
+###EBSCO updates
+- Consortia can use both EBSCOhost and EDS. Only one of these may be active for a single library at a time. Aspen will defer to EDS if both have search settings, but if EDS search settings are set to "none" EBSCOhost will be the active Articles & Databases search source.
+
 ###PayPal Updates
 - If no reason is provided for a fine, pass the message to PayPal as the name of the fine. (Ticket 101191)
 

--- a/code/web/sys/ExploreMore.php
+++ b/code/web/sys/ExploreMore.php
@@ -120,11 +120,11 @@ class ExploreMore {
 
 		$exploreMoreOptions = $this->loadCatalogOptions($activeSection, $exploreMoreOptions, $searchTerm);
 
-		if (array_key_exists('EBSCO EDS', $enabledModules)) {
+		if (array_key_exists('EBSCO EDS', $enabledModules) && $library->edsSettingsId != -1) {
 			$exploreMoreOptions = $this->loadEbscoEDSOptions($activeSection, $exploreMoreOptions, $searchTerm);
 		}
 
-		if (array_key_exists('EBSCOhost', $enabledModules)) {
+		else if (array_key_exists('EBSCOhost', $enabledModules) && $library->edsSettingsId == -1) {
 			$exploreMoreOptions = $this->loadEbscohostOptions($activeSection, $exploreMoreOptions, $searchTerm);
 		}
 

--- a/code/web/sys/LibraryLocation/CombinedResultSection.php
+++ b/code/web/sys/LibraryLocation/CombinedResultSection.php
@@ -11,6 +11,7 @@ abstract class CombinedResultSection extends DataObject{
 	static function getObjectStructure() : array {
 		global $configArray;
 		global $enabledModules;
+        global $library;
 		$validResultSources = array();
 		$validResultSources['catalog'] = 'Catalog Results';
 		require_once ROOT_DIR . '/sys/Enrichment/DPLASetting.php';
@@ -18,10 +19,10 @@ abstract class CombinedResultSection extends DataObject{
 		if ($dplaSetting->find(true)){
 			$validResultSources['dpla'] = 'DP.LA';
 		}
-		if (array_key_exists('EBSCO EDS', $enabledModules)) {
+		if (array_key_exists('EBSCO EDS', $enabledModules) && $library->edsSettingsId != -1) {
 			$validResultSources['ebsco_eds'] = 'EBSCO EDS';
 		}
-		if (array_key_exists('EBSCOhost', $enabledModules)) {
+		else if (array_key_exists('EBSCOhost', $enabledModules) && $library->edsSettingsId == -1) {
 			$validResultSources['ebscohost'] = 'EBSCOhost';
 		}
 		if (array_key_exists('Events', $enabledModules)){


### PR DESCRIPTION
If both modules are enabled and settings/search settings exist for both EDS will be preferred and will be the only option that shows in the search source, explore more, and combined results. If EDS settings are set to "none" EBSCOhost will be the only option in these areas. This should make it easy for libraries to use either/or within a consortium that uses both