### PR TITLE
Collection Spotlight: View More Link

### DIFF
--- a/code/web/interface/themes/responsive/CollectionSpotlight/collectionSpotlightTabs.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/collectionSpotlightTabs.tpl
@@ -2,21 +2,17 @@
 <div id="collectionSpotlight{$collectionSpotlight->id}" class="{if count($collectionSpotlight->lists) > 1}ui-tabs {/if}collectionSpotlight {$collectionSpotlight->style}">
 	{if count($collectionSpotlight->lists) > 1}
 		{if !isset($collectionSpotlight->listDisplayType) || $collectionSpotlight->listDisplayType == 'tabs'}
+			{*Display Title Scroller Header*}
 			<div id="{$list->name|regex_replace:'/\W/':''|escape:url}" class="titleScrollerWrapper singleTitleSpotlightWrapper">
-				{if $collectionSpotlight->showSpotlightTitle || $collectionSpotlight->showViewMoreLink}
+				{if $collectionSpotlight->showSpotlightTitle}
 					<div id="list-{$list->name|regex_replace:'/\W/':''|escape:url}Header" class="titleScrollerHeader">
-						{foreach from=$collectionSpotlight->lists item=list name=spotlightList}
-							{assign var="fullListLink" value=$list->fullListLink()}
-						{/foreach}
 						{if $collectionSpotlight->showSpotlightTitle && !empty($collectionSpotlight->name)}
 							<span class="listTitle resultInformationLabel">{if $collectionSpotlight->name}{translate text=$collectionSpotlight->name isPublicFacing=true isAdminEnteredData=true}{/if}</span>
-						{/if}
-						{if $collectionSpotlight->showViewMoreLink}
-							<div id="titleScrollerViewMore{$listName}" class="titleScrollerViewMore"><a href="{$fullListLink}">{translate text="View More" isPublicFacing=true}</a></div>
 						{/if}
 					</div>
 				{/if}
 			</div>
+
 			{* Display Tabs *}
 			<ul class="nav nav-tabs" role="tablist">
 				{foreach from=$collectionSpotlight->lists item=list name=spotlightList}
@@ -55,10 +51,11 @@
 				{assign var="scrollerVariable" value="listScroller$listName"}
 				{assign var="fullListLink" value=$list->fullListLink()}
 				{assign var="scrollerTitle" value=$collectionSpotlight->name}
+				{assign var="fullListLink" value=$list->fullListLink()}
+				{assign var="showViewMoreLink" value=$collectionSpotlight->showViewMoreLink}
 
 				{if count($collectionSpotlight->lists) == 1}
 					{assign var="scrollerTitle" value=$collectionSpotlight->name}
-					{assign var="showViewMoreLink" value=$collectionSpotlight->showViewMoreLink}
 					{assign var="showCollectionSpotlightTitle" value=$collectionSpotlight->showSpotlightTitle}
 				{/if}
 				{if !isset($collectionSpotlight->listDisplayType) || $collectionSpotlight->listDisplayType == 'tabs'}
@@ -70,6 +67,7 @@
 						{assign var="display" value="false"}
 					{/if}
 				{/if}
+
 				{if $collectionSpotlight->style == 'horizontal'}
 					{include file='CollectionSpotlight/titleScroller.tpl'}
 				{elseif $collectionSpotlight->style == 'horizontal-carousel'}

--- a/code/web/interface/themes/responsive/CollectionSpotlight/horizontalCarousel.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/horizontalCarousel.tpl
@@ -1,11 +1,8 @@
 <div id="list-{$wrapperId}"{if !empty($display) && $display == 'false'} style="display:none"{/if} class="titleScroller tab-pane{if !empty($active)} active{/if}{if !empty($collectionSpotlight) && $collectionSpotlight->coverSize == 'medium'} mediumScroller{/if}{if !empty($collectionSpotlight) && $collectionSpotlight->showRatings} scrollerWithRatings{/if}">
-{if $showCollectionSpotlightTitle || $showViewMoreLink}
+{if $showCollectionSpotlightTitle}
 	<div id="list-{$wrapperId}Header" class="titleScrollerHeader">
 		{if $showCollectionSpotlightTitle && !empty($scrollerTitle)}
 			<span class="listTitle resultInformationLabel">{if $scrollerTitle}{translate text=$scrollerTitle isPublicFacing=true isAdminEnteredData=true}{/if}</span>
-		{/if}
-		{if $showViewMoreLink}
-			<div id="titleScrollerViewMore{$scrollerName}" class="titleScrollerViewMore"><a href="{$fullListLink}">{translate text="View More" isPublicFacing=true}</a></div>
 		{/if}
 	</div>
 {/if}
@@ -16,6 +13,10 @@
 
 	<a href="#" class="jcarousel-control-prev" aria-label="{translate text="Previous Item" isPublicFacing=true inAttribute=true}"><i class="fas fa-caret-left"></i></a>
 	<a href="#" class="jcarousel-control-next" aria-label="{translate text="Next Item" isPublicFacing=true inAttribute=true}"><i class="fas fa-caret-right"></i></a>
+
+	{if $showViewMoreLink}
+		<div id="titleScrollerViewMore{$scrollerName}" class="titleScrollerViewMore"><a href="{$fullListLink}">{translate text="View More" isPublicFacing=true}</a></div>
+	{/if}
 </div>
 <script type="text/javascript">
 	$(document).ready(function(){ldelim}

--- a/code/web/interface/themes/responsive/CollectionSpotlight/titleScroller.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/titleScroller.tpl
@@ -1,18 +1,11 @@
 {strip}
 <div id="list-{$wrapperId}"{if !empty($display) && $display == 'false'} style="display:none"{/if} class="titleScroller tab-pane{if !empty($active)} active{/if}{if !empty($collectionSpotlight) && $collectionSpotlight->coverSize == 'medium'} mediumScroller{/if}{if !empty($collectionSpotlight) && $collectionSpotlight->showRatings} scrollerWithRatings{/if}">
 	<div id="{$wrapperId}" class="titleScrollerWrapper">
-		{if !empty($showCollectionSpotlightTitle) || !empty($showViewMoreLink) || !empty($Links)}
+		{if (!empty($showCollectionSpotlightTitle))}
 			<div id="list-{$wrapperId}Header" class="titleScrollerHeader">
 				{if !empty($showCollectionSpotlightTitle)}
 					<span class="listTitle resultInformationLabel">{if $scrollerTitle}{translate text=$scrollerTitle isPublicFacing=true isAdminEnteredData=true}{/if}</span>
 				{/if}
-
-				{if !empty($showViewMoreLink) && strlen($fullListLink) > 0}
-					<div class="linkTab" style="float:right">
-						<a href='{$fullListLink}'><span class="seriesLink">{translate text="View More" isPublicFacing=true}</span></a>
-					</div>
-				{/if}
-
 			</div>
 		{/if}
 		<div id="titleScroller{$scrollerName}" class="titleScrollerBody">
@@ -32,6 +25,11 @@
 				<div id="titleScrollerSelectedAuthor{$scrollerName}" class="titleScrollerSelectedAuthor notranslate"></div>
 			{/if}
 		</div>
+		{if !empty($showViewMoreLink) && strlen($fullListLink) > 0}
+			<div class="linkTab" style="float:right">
+				<a href='{$fullListLink}'><span class="seriesLink">{translate text="View More" isPublicFacing=true}</span></a>
+			</div>
+		{/if}
 	</div>
 </div>
 <script type="text/javascript">

--- a/code/web/release_notes/22.09.00.MD
+++ b/code/web/release_notes/22.09.00.MD
@@ -1,5 +1,5 @@
 
 ###Other Updates
--  
+-  Fixed an issue with the View More link for tabbed spotlights not redirecting to the correct list (Ticket 100983)
 
 _end release notes_

--- a/code/web/sys/LocalEnrichment/CollectionSpotlight.php
+++ b/code/web/sys/LocalEnrichment/CollectionSpotlight.php
@@ -201,7 +201,7 @@ class CollectionSpotlight extends DataObject
 			'showViewMoreLink' => array(
 				'property' => 'showViewMoreLink',
 				'type' => 'checkbox',
-				'label' => 'Show the View More link on the title bar of the display.',
+				'label' => 'Show the View More link',
 				'storeDb' => true,
 				'hideInLists' => true,
 				'default' => false,


### PR DESCRIPTION
Fixed the view more link for tabbed spotlights not redirecting to the correct list. The view more link is now placed under the book covers (bottom right) for the horizontal/horizontal carousel. Updated release notes