### PR TITLE
Hide Unknown/Not Coded

### DIFF
--- a/code/reindexer/src/com/turning_leaf_technologies/reindexer/GroupedWorkSolr2.java
+++ b/code/reindexer/src/com/turning_leaf_technologies/reindexer/GroupedWorkSolr2.java
@@ -99,15 +99,26 @@ public class GroupedWorkSolr2 extends AbstractGroupedWorkSolr implements Cloneab
 			doc.addField("geographic", geographic);
 			doc.addField("geographic_facet", geographicFacets);
 			doc.addField("era", eras);
+			//Check default values and inconsistent forms
 			checkDefaultValue(literaryFormFull, "Not Coded");
 			checkDefaultValue(literaryFormFull, "Other");
 			checkDefaultValue(literaryFormFull, "Unknown");
 			checkInconsistentLiteraryFormsFull();
-			doc.addField("literary_form_full", literaryFormFull.keySet());
 			checkDefaultValue(literaryForm, "Not Coded");
 			checkDefaultValue(literaryForm, "Other");
 			checkDefaultValue(literaryForm, "Unknown");
 			checkInconsistentLiteraryForms();
+			//Check if .isHide
+			if (groupedWorkIndexer.isHideUnknownLiteraryForm()) {
+				literaryForm.remove("Unknown");
+				literaryFormFull.remove("Unknown");
+			}
+			if (groupedWorkIndexer.isHideNotCodedLiteraryForm()) {
+				literaryForm.remove("Not Coded");
+				literaryFormFull.remove("Not Coded");
+			}
+			//Add field
+			doc.addField("literary_form_full", literaryFormFull.keySet());
 			doc.addField("literary_form", literaryForm.keySet());
 			if (targetAudienceFull.size() > 1 || !groupedWorkIndexer.isTreatUnknownAudienceAsUnknown()) {
 				targetAudienceFull.remove("Unknown");

--- a/code/web/release_notes/22.09.00.MD
+++ b/code/web/release_notes/22.09.00.MD
@@ -1,5 +1,6 @@
 
 ###Other Updates
--  Fixed an issue with the View More link for tabbed spotlights not redirecting to the correct list (Ticket 100983)
+- Fixed an issue with the View More link for tabbed spotlights not redirecting to the correct list (Ticket 100983)
+- Fixed an issue where Hide Unknown/Not Coded lit forms was not working correctly (Ticket 97288)
 
 _end release notes_


### PR DESCRIPTION
Adds checks to GroupedWorkSolr2.java to hide Unknown and Not Coded lit forms if that is chosen in Indexing Profiles. Also updated 22.09.00 release notes