### PR TITLE
Improves View More links in tabbed Collection Spotlights

### DIFF
--- a/code/web/interface/themes/responsive/CollectionSpotlight/collectionSpotlightTabs.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/collectionSpotlightTabs.tpl
@@ -49,11 +49,13 @@
 				{assign var="scrollerName" value="$listName"}
 				{assign var="wrapperId" value="$listName"}
 				{assign var="scrollerVariable" value="listScroller$listName"}
-				{assign var="fullListLink" value=$list->fullListLink()}
 				{assign var="scrollerTitle" value=$collectionSpotlight->name}
 				{assign var="fullListLink" value=$list->fullListLink()}
 				{assign var="showViewMoreLink" value=$collectionSpotlight->showViewMoreLink}
-
+				{if count($collectionSpotlight->lists) > 1}
+					{assign var="showViewMoreListTitle" value=$list->name}
+				{/if}
+				
 				{if count($collectionSpotlight->lists) == 1}
 					{assign var="scrollerTitle" value=$collectionSpotlight->name}
 					{assign var="showCollectionSpotlightTitle" value=$collectionSpotlight->showSpotlightTitle}

--- a/code/web/interface/themes/responsive/CollectionSpotlight/horizontalCarousel.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/horizontalCarousel.tpl
@@ -15,7 +15,7 @@
 	<a href="#" class="jcarousel-control-next" aria-label="{translate text="Next Item" isPublicFacing=true inAttribute=true}"><i class="fas fa-caret-right"></i></a>
 
 	{if $showViewMoreLink}
-		<div id="titleScrollerViewMore{$scrollerName}" class="titleScrollerViewMore"><a href="{$fullListLink}">{translate text="View More" isPublicFacing=true}</a></div>
+		<div id="titleScrollerViewMore{$scrollerName}" class="titleScrollerViewMore"><a href="{$fullListLink}">{translate text="View More" isPublicFacing=true}{if $showViewMoreListTitle} {translate text="$showViewMoreListTitle" isPublicFacing=true}{/if}</a></div>
 	{/if}
 </div>
 <script type="text/javascript">


### PR DESCRIPTION
In tabbed Collection Spotlights, includes the CS name in the View More link text.

E.g., if a tabbed CS included CSes named Unicorns, Glitter, Rainbows, and Glitter is selected, the View More link would read "View More Glitter", and when clicked would take the patron to the search described in the Glitter CS admin page.