### PR TITLE
Reindex Grouped Works with IDs that contain spaces

### DIFF
--- a/code/reindexer/src/com/turning_leaf_technologies/grouping/BaseMarcRecordGrouper.java
+++ b/code/reindexer/src/com/turning_leaf_technologies/grouping/BaseMarcRecordGrouper.java
@@ -584,7 +584,7 @@ public abstract class BaseMarcRecordGrouper extends RecordGroupingProcessor {
 		if (activeLanguage == null){
 			if (treatUnknownLanguageAs.length() > 0){
 				activeLanguage = translateValue("language_to_three_letter_code", treatUnknownLanguageAs);
-				if (activeLanguage.length() != 3){
+				if (activeLanguage.length() != 3 || activeLanguage.contains(" ")){
 					activeLanguage = "unk";
 				}
 			}else {

--- a/code/reindexer/src/com/turning_leaf_technologies/grouping/RecordGroupingProcessor.java
+++ b/code/reindexer/src/com/turning_leaf_technologies/grouping/RecordGroupingProcessor.java
@@ -901,7 +901,7 @@ public class RecordGroupingProcessor {
 				}
 			}
 		}
-		if (activeLanguage == null || activeLanguage.equals("|||") || activeLanguage.equals("   ")){
+		if (activeLanguage == null || activeLanguage.equals("|||") || activeLanguage.equals("   ") || activeLanguage.contains(" ")){
 			activeLanguage = "unk";
 		}
 		return activeLanguage;

--- a/code/web/sys/DBMaintenance/version_updates/22.09.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/22.09.00.php
@@ -2,7 +2,8 @@
 /** @noinspection PhpUnused */
 function getUpdates22_09_00() : array
 {
-	return [
+    $curTime = time();
+    return [
 		/*'name' => [
 			'title' => '',
 			'description' => '',
@@ -334,6 +335,13 @@ function getUpdates22_09_00() : array
 		], //add_logoNotification
 
 		//kodi
+        'force_reindex_of_records_with_spaces' => [
+            'title' => 'Force records to reindex if there are spaces in the grouped work ID',
+            'description' => 'Force records to reindex if there are spaces in the grouped work ID',
+            'sql' => [
+                "INSERT INTO grouped_work_scheduled_index (permanent_id,processed, indexAfter) SELECT permanent_id, 0, $curTime FROM grouped_work where permanent_id REGEXP '.*[\s]+$'",
+            ]
+        ], //force_reindex_of_records_with_spaces
 
 		//other
 		'hide_subject_facet_permission' => [


### PR DESCRIPTION
Reindex grouped works with IDs that contain spaces. Added to the checks to look for spaces in 008 language field