### PR TITLE
Fix for installer overwriting php7.3 with php8.1

### DIFF
--- a/install/installer_debian.sh
+++ b/install/installer_debian.sh
@@ -16,7 +16,7 @@ apt install -y bind9 bind9utils
 apt install -y php7.3-intl
 apt install -y php7.3-mbstring
 apt install -y php7.3-pgsql
-apt install -y php-ssh2
+apt install -y php7.3-ssh2
 service apache2 start
 systemctl enable apache2
 # New PHP ini file


### PR DESCRIPTION
* On Debian 10 and Debian 11, php8.1 is selected by the sury list erroneously.
* This proposition will resolve this problem, by specifying to apt which version to use.