### PR TITLE
Evergreen Driver: change patron type to use correct field

### DIFF
--- a/code/web/Drivers/Evergreen.php
+++ b/code/web/Drivers/Evergreen.php
@@ -1075,7 +1075,7 @@ class Evergreen extends AbstractIlsDriver
 			$user->phone = $userData['other_phone'];
 		}
 
-		$user->patronType = $userData['usrgroup'];
+		$user->patronType = $userData['profile'];
 
 		//TODO: Figure out how to parse the address we will need to look it up in web services
 		//$fullAddress = $userData['mailing_address'];


### PR DESCRIPTION
Otherwise, any hold limit set at the Aspen patron type level would not be enforced.