### PR TITLE
Evergreen Driver: fix crash when displaying certain fines

### DIFF
--- a/code/web/Drivers/Evergreen.php
+++ b/code/web/Drivers/Evergreen.php
@@ -932,23 +932,21 @@ class Evergreen extends AbstractIlsDriver
 			if ($this->apiCurlWrapper->getResponseCode() == 200) {
 				$apiResponse = json_decode($apiResponse);
 				if (isset($apiResponse->payload)){
-					foreach ($apiResponse->payload[0] as $transactionList){
-						foreach ($transactionList as $transactionObj){
-							$transaction = $transactionObj->__p;
-							$transactionObj = $this->mapEvergreenFields($transaction, $this->fetchIdl('mbts'));
-							$curFine = [
-								'fineId' => $transactionObj['id'],
-								'date' => strtotime($transactionObj['xact_start']),
-								'type' => $transactionObj['xact_type'],
-								'reason' => $transactionObj['last_billing_type'],
-								'message' => $transactionObj['last_billing_note'],
-								'amountVal' => $transactionObj['total_owed'],
-								'amountOutstandingVal' => $transactionObj['total_owed'] - $transactionObj['total_paid'],
-								'amount' => $currencyFormatter->formatCurrency($transactionObj['total_owed'], $currencyCode),
-								'amountOutstanding' => $currencyFormatter->formatCurrency($transactionObj['total_owed'] - $transactionObj['total_paid'], $currencyCode),
-							];
-							$fines[] = $curFine;
-						}
+					foreach ($apiResponse->payload[0] as $transactionObj){
+						$transaction = $transactionObj->transaction->__p;
+						$transactionObj = $this->mapEvergreenFields($transaction, $this->fetchIdl('mbts'));
+						$curFine = [
+							'fineId' => $transactionObj['id'],
+							'date' => strtotime($transactionObj['xact_start']),
+							'type' => $transactionObj['xact_type'],
+							'reason' => $transactionObj['last_billing_type'],
+							'message' => $transactionObj['last_billing_note'],
+							'amountVal' => $transactionObj['total_owed'],
+							'amountOutstandingVal' => $transactionObj['total_owed'] - $transactionObj['total_paid'],
+							'amount' => $currencyFormatter->formatCurrency($transactionObj['total_owed'], $currencyCode),
+							'amountOutstanding' => $currencyFormatter->formatCurrency($transactionObj['total_owed'] - $transactionObj['total_paid'], $currencyCode),
+						];
+						$fines[] = $curFine;
 					}
 				}
 			}


### PR DESCRIPTION
When a set of billings is associated with a checkout, the response from open-ils.actor.user.transactions.have_charge.fleshed for the underlying transaction will have additional keys with more details about the loan and the title associated with the loan. The billing summary record is the value of the 'transaction' key in all cases, however.

To put it another way, the response from that method is an array of hashes, each of which is guaranteed to have a 'transaction' key, while most but not all will have additional keys.

This patch fixes the handling of the response and avoids a crash that causes no fines to be displayed if one of them is associated with a checkout.

Further enhancement is possible to include title, author, due date, etc. in the Aspen fines display.