### PR TITLE
Updates to Large Print Check

### DIFF
--- a/code/reindexer/src/com/turning_leaf_technologies/reindexer/IlsRecordProcessor.java
+++ b/code/reindexer/src/com/turning_leaf_technologies/reindexer/IlsRecordProcessor.java
@@ -1554,36 +1554,37 @@ abstract class IlsRecordProcessor extends MarcRecordProcessor {
 	/**
 	 * Determine Record Format(s)
 	 */
-	public void loadPrintFormatInformation(RecordInfo recordInfo, Record record){
-		//We should already have formats based on the items
-		if (formatSource.equals("item") && formatSubfield != ' ' && recordInfo.hasItemFormats()){
-			//Check to see if all items have formats.
-			if (!recordInfo.allItemsHaveFormats()){
-				HashSet<String> uniqueItemFormats = recordInfo.getUniqueItemFormats();
-				if (uniqueItemFormats.size() == 1) {
-					recordInfo.addFormat(uniqueItemFormats.iterator().next());
-					recordInfo.addFormatCategory(recordInfo.getFirstItemFormatCategory());
-					try {
-						if (checkRecordForLargePrint && (uniqueItemFormats.size() == 1) && uniqueItemFormats.iterator().next().equals("Book")) {
-							LinkedHashSet<String> printFormats = getFormatsFromBib(record, recordInfo);
-							if (printFormats.size() == 1 && printFormats.iterator().next().contains("LargePrint")) {
-								String translatedFormat = translateValue("format", "LargePrint", recordInfo.getRecordIdentifier());
-								//noinspection Java8MapApi
-								for (String itemType : uniqueItemFormats) {
-									uniqueItemFormats.remove(itemType);
-									uniqueItemFormats.add(translatedFormat);
-								}
-							}
-						}
-					} catch (Exception e) {
-						logger.error("Error checking record for large print");
-					}
-					return;
-				}
-			}else {
-				return;
-			}
-		}
+    public void loadPrintFormatInformation(RecordInfo recordInfo, Record record){
+        //We should already have formats based on the items
+        if (formatSource.equals("item") && formatSubfield != ' ' && recordInfo.hasItemFormats()){
+            //Check to see if all items have formats.
+            if (!recordInfo.allItemsHaveFormats()){
+                HashSet<String> uniqueItemFormats = recordInfo.getUniqueItemFormats();
+                if (uniqueItemFormats.size() == 1) {
+                    recordInfo.addFormat(uniqueItemFormats.iterator().next());
+                    recordInfo.addFormatCategory(recordInfo.getFirstItemFormatCategory());
+                }
+            }else {
+                HashSet<String> uniqueItemFormats = recordInfo.getUniqueItemFormats();
+                try {
+                    if (checkRecordForLargePrint && (uniqueItemFormats.size() == 1) && uniqueItemFormats.iterator().next().equalsIgnoreCase("Book")) {
+                        LinkedHashSet<String> printFormats = getFormatsFromBib(record, recordInfo);
+                        if (printFormats.size() == 1 && printFormats.iterator().next().contains("LargePrint")) {
+                            String translatedFormat = translateValue("format", "LargePrint", recordInfo.getRecordIdentifier());
+                            //noinspection Java8MapApi
+                            for (String itemType : uniqueItemFormats) {
+                                uniqueItemFormats.remove(itemType);
+                                uniqueItemFormats.add(translatedFormat);
+                                recordInfo.addFormat(translatedFormat);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    logger.error("Error checking record for large print");
+                }
+                return;
+            }
+        }
 
 		//If not, we will assign format based on bib level data
 		if (formatSource.equals("specified")){

--- a/code/reindexer/src/com/turning_leaf_technologies/reindexer/IlsRecordProcessor.java
+++ b/code/reindexer/src/com/turning_leaf_technologies/reindexer/IlsRecordProcessor.java
@@ -1550,7 +1550,6 @@ abstract class IlsRecordProcessor extends MarcRecordProcessor {
 
 		return new ResultWithNotes(false, suppressionNotes);
 	}
-
 	/**
 	 * Determine Record Format(s)
 	 */
@@ -1563,25 +1562,10 @@ abstract class IlsRecordProcessor extends MarcRecordProcessor {
                 if (uniqueItemFormats.size() == 1) {
                     recordInfo.addFormat(uniqueItemFormats.iterator().next());
                     recordInfo.addFormatCategory(recordInfo.getFirstItemFormatCategory());
-                }
+					largePrintCheck(recordInfo, record);
+				}
             }else {
-                HashSet<String> uniqueItemFormats = recordInfo.getUniqueItemFormats();
-                try {
-                    if (checkRecordForLargePrint && (uniqueItemFormats.size() == 1) && uniqueItemFormats.iterator().next().equalsIgnoreCase("Book")) {
-                        LinkedHashSet<String> printFormats = getFormatsFromBib(record, recordInfo);
-                        if (printFormats.size() == 1 && printFormats.iterator().next().contains("LargePrint")) {
-                            String translatedFormat = translateValue("format", "LargePrint", recordInfo.getRecordIdentifier());
-                            //noinspection Java8MapApi
-                            for (String itemType : uniqueItemFormats) {
-                                uniqueItemFormats.remove(itemType);
-                                uniqueItemFormats.add(translatedFormat);
-                                recordInfo.addFormat(translatedFormat);
-                            }
-                        }
-                    }
-                } catch (Exception e) {
-                    logger.error("Error checking record for large print");
-                }
+				largePrintCheck(recordInfo, record);
                 return;
             }
         }
@@ -1597,6 +1581,26 @@ abstract class IlsRecordProcessor extends MarcRecordProcessor {
 			recordInfo.setFormatBoost(specifiedFormatBoost);
 		} else {
 			loadPrintFormatFromBib(recordInfo, record);
+		}
+	}
+
+	void largePrintCheck(RecordInfo recordInfo, Record record){
+		HashSet<String> uniqueItemFormats = recordInfo.getUniqueItemFormats();
+		try {
+			if (checkRecordForLargePrint && (uniqueItemFormats.size() == 1) && uniqueItemFormats.iterator().next().equalsIgnoreCase("Book")) {
+				LinkedHashSet<String> printFormats = getFormatsFromBib(record, recordInfo);
+				if (printFormats.size() == 1 && printFormats.iterator().next().contains("LargePrint")) {
+					String translatedFormat = translateValue("format", "LargePrint", recordInfo.getRecordIdentifier());
+					//noinspection Java8MapApi
+					for (String itemType : uniqueItemFormats) {
+						uniqueItemFormats.remove(itemType);
+						uniqueItemFormats.add(translatedFormat);
+						recordInfo.addFormat(translatedFormat);
+					}
+				}
+			}
+		} catch (Exception e) {
+			logger.error("Error checking record for large print");
 		}
 	}
 


### PR DESCRIPTION
Updates to logic for checking for large print. Check did not work when nested under if (!recordInfo.allItemsHaveFormats()). Also added recordInfo.addFormat(translatedFormat) on line 1578 to add the translated format to the correct place.