### PR TITLE
Add ability to view IdP metadata

### DIFF
--- a/code/web/app/viewIdpMetadata.php
+++ b/code/web/app/viewIdpMetadata.php
@@ -1,0 +1,38 @@
+<?php
+
+	require_once '../bootstrap.php';
+	require_once '../sys/Authentication/SAML2Authentication.php';
+
+	global $library;
+
+	$auth = new SAML2Authentication('/app/viewIdpMetadata.php');
+
+	// If we need to forward the user to an IdP
+	$url = $library->ssoXmlUrl;
+	if (
+		array_key_exists('samlLogin', $_REQUEST) &&
+		array_key_exists('idp', $_REQUEST) &&
+		strlen($_REQUEST['samlLogin']) > 0 &&
+		strlen($_REQUEST['idp']) > 0 &&
+		$url &&
+		strlen($url) > 0
+	) {
+		$auth->authenticate($_REQUEST['idp']);
+		header('Location: /');
+	}
+
+	// We are processing the result of authenticating
+	// with the IdP
+
+	// Get the attributes from the IdP response
+	$usersAttributes = $auth->as->getAttributes();
+
+	// Someone has most likely hit this script directly, rather than having
+	// come back from an IdP
+	if (count($usersAttributes) == 0) {
+		$logger->log("No SSO attributes found",  Logger::LOG_ERROR);
+		header('Location: /');
+	}
+
+	print "<pre>";
+	print_r($usersAttributes);

--- a/code/web/sys/Authentication/SAML2Authentication.php
+++ b/code/web/sys/Authentication/SAML2Authentication.php
@@ -7,10 +7,12 @@ class SAML2Authentication {
     public $as;
 	public $configProperties;
 	public $requestMap;
+	public $returnTo;
 
-    public function __construct() {
+    public function __construct($returnUrl = '/saml2auth.php') {
         $this->as = new \SimpleSAML\Auth\Simple('default-sp');
 		$this->configProperties = $this->SAMLConfigProperties();
+		$this->returnTo = $returnUrl;
     }
 
     public function authenticate($idp) {
@@ -18,7 +20,7 @@ class SAML2Authentication {
             $this->as->login(array(
                 'saml:idp' => $idp,
                 'KeepPost' => FALSE,
-                'ReturnTo' => '/saml2auth.php',
+                'ReturnTo' => $this->returnTo
             ));
         } else {
             return false;


### PR DESCRIPTION
In order to configure Aspen to work with an SSO IdP we need to know what attributes are being used for what data in the metadata that comes back from the IdP. This commit adds a new viewIdpMetadata.php page that, when called forwards the user to the IdP and, upon authentication, then dumps the metadata that is subsequently received

PR note: @mdnoble73 I think you merged my last commit into 22.09.01 (since the rest of the stuff went into 22.09.00 I think), should we do the same here? If so, does this also get pulled forward into 22.10.00?