### PR TITLE
AJAX updates

### DIFF
--- a/code/web/release_notes/22.10.00.MD
+++ b/code/web/release_notes/22.10.00.MD
@@ -104,5 +104,6 @@
 -Fix "Duplicate HooplaId" Error (Ticket 93619)
 -Fixed a language issue that cause invalid grouped work ids to be created (Tickets 100476 & 104038)
 -Fixed an error bots were throwing with Prospector searches
+-Fixed an error when trying to place a hold on records that no longer exist
 
 //Other

--- a/code/web/release_notes/22.10.00.MD
+++ b/code/web/release_notes/22.10.00.MD
@@ -95,12 +95,14 @@
 - Added check for wonderbooks in filterPrintFormats() (Ticket 100407)
 - 250a field now checked for: Playaway, Playaway View, Wonderbook, GameCube, Nintendo Switch, Book Club Kit, Vox (Ticket 101367)
 - 300a field now checked for: Playaway View and Wonderbook (Ticket 95261)
-- 538 field now checked for: 4k ultra hd blu-ray (Tickets 95261, 89326)
-- Added check for volume/volumes/v. in 300a field (Ticket 101090)
-- 250a field now checked for: pop-up books (Ticket 85476)
+- 538 field now checked for: "4k" and "blu-ray" OR "4k" and "bluray" for 4K Blu-Ray format (Tickets 95261, 89326)
+- Added check for volume/volumes/v. in 300a field to help identify Book+CD formats (Ticket 101090)
+- 250a field now checked for: "pop-up" and "mini-pop-up" for pop-up books (Ticket 85476)
+- 650a and 655a fields now check for: "toy and movable books" and "pop-up" for pop-up books (Ticket 85476)
 
 ###Other Updates
 -Fix "Duplicate HooplaId" Error (Ticket 93619)
 -Fixed a language issue that cause invalid grouped work ids to be created (Tickets 100476 & 104038)
+-Fixed an error bots were throwing with Prospector searches
 
 //Other

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -618,9 +618,13 @@ class Record_AJAX extends Action
 								$groupedWorkId = $recordDriver->getPermanentId();
 								require_once ROOT_DIR . '/RecordDrivers/GroupedWorkDriver.php';
 								$groupedWorkDriver = new GroupedWorkDriver($groupedWorkId);
-								$whileYouWaitTitles = $groupedWorkDriver->getWhileYouWait();
+                                if ($groupedWorkDriver->isValid()){
+                                    $whileYouWaitTitles = $groupedWorkDriver->getWhileYouWait();
 
-								$interface->assign('whileYouWaitTitles', $whileYouWaitTitles);
+                                    $interface->assign('whileYouWaitTitles', $whileYouWaitTitles);
+                                }else{
+                                    $interface->assign('whileYouWaitTitles', []);
+                                }
 							}
 						}else{
 							$interface->assign('whileYouWaitTitles', []);

--- a/code/web/services/Search/AJAX.php
+++ b/code/web/services/Search/AJAX.php
@@ -117,23 +117,30 @@ class AJAX extends Action {
 		$searchObject->init();
 		$searchObject = $searchObject->restoreSavedSearch($prospectorSavedSearchId, false);
 
-		//Load results from Prospector
-		$prospector = new Prospector();
+        if (!empty($searchObject->id)) {
+            //Load results from Prospector
+            $prospector = new Prospector();
 
-		// Only show prospector results within search results if enabled
-		if ($library && $library->enableProspectorIntegration && $library->showProspectorResultsAtEndOfSearch){
-			$prospectorResults = $prospector->getTopSearchResults($searchObject->getSearchTerms(), 5);
-			$interface->assign('prospectorResults', $prospectorResults['records']);
-		}
+            // Only show prospector results within search results if enabled
+            if ($library && $library->enableProspectorIntegration && $library->showProspectorResultsAtEndOfSearch) {
+                $prospectorResults = $prospector->getTopSearchResults($searchObject->getSearchTerms(), 5);
+                $interface->assign('prospectorResults', $prospectorResults['records']);
+            }
 
-		$prospectorLink = $prospector->getSearchLink($searchObject->getSearchTerms());
-		$interface->assign('prospectorLink', $prospectorLink);
-		$timer->logTime('load Prospector titles');
-		//echo $interface->fetch('Search/ajax-innreach.tpl');
-		return array(
-			'numTitles' => count($prospectorResults),
-			'formattedData' => $interface->fetch('Search/ajax-innreach.tpl')
-		);
+            $prospectorLink = $prospector->getSearchLink($searchObject->getSearchTerms());
+            $interface->assign('prospectorLink', $prospectorLink);
+            $timer->logTime('load Prospector titles');
+            //echo $interface->fetch('Search/ajax-innreach.tpl');
+            return array(
+                'numTitles' => count($prospectorResults),
+                'formattedData' => $interface->fetch('Search/ajax-innreach.tpl')
+            );
+        }else{
+            return array(
+                'numTitles' => 0,
+                'formattedData' => ''
+            );
+        }
 	}
 
 	/**


### PR DESCRIPTION
Return empty string when saved search ID no longer exists for AJAX prospector. Updated release notes. Side Note: needed to use ($searchObject->id) to catch the IDs that have been purged from the database. Without the "->id" the error still gets thrown.