### PR TITLE
Fix content type of forms

### DIFF
--- a/code/web/services/Admin/ObjectEditor.php
+++ b/code/web/services/Admin/ObjectEditor.php
@@ -256,16 +256,26 @@ abstract class ObjectEditor extends Admin_Admin
 		}
 		$interface->assign('object', $existingObject);
 		//Check to see if the request should be multipart/form-data
-		$contentType = null;
-		foreach ($structure as $property){
-			if ($property['type'] == 'image' || $property['type'] == 'file'){
-				$contentType = 'multipart/form-data';
-			}
-		}
+		$contentType = $this->getFormContentType($structure);
 		$interface->assign('contentType', $contentType);
 
 		$interface->assign('additionalObjectActions', $this->getAdditionalObjectActions($existingObject));
 		$interface->setTemplate('../Admin/objectEditor.tpl');
+	}
+
+	function getFormContentType($structure, $contentType = null) {
+		if ($contentType != null) {
+			return $contentType;
+		}
+		//Check to see if the request should be multipart/form-data
+		foreach ($structure as $property){
+			if ($property['type'] == 'section') {
+				$contentType = $this->getFormContentType($property['properties'], $contentType);
+			} else if ($property['type'] == 'image' || $property['type'] == 'file'){
+				$contentType = 'multipart/form-data';
+			}
+		}
+		return $contentType;
 	}
 
 	function editObject($objectAction, $structure){

--- a/code/web/sys/DataObjectUtil.php
+++ b/code/web/sys/DataObjectUtil.php
@@ -18,15 +18,25 @@ class DataObjectUtil
 		//Define the structure of the object.
 		$interface->assign('structure', $objectStructure);
 		//Check to see if the request should be multipart/form-data
-		$contentType = null;
-		foreach ($objectStructure as $property){
-			if ($property['type'] == 'image' || $property['type'] == 'file'){
-				$contentType = 'multipart/form-data';
-			}
-		}
+		$contentType = $this->getFormContentType($structure);
 		$interface->assign('contentType', $contentType);
 		$interface->assign('formLabel', 'Edit ' . $contentType);
 		return  $interface->fetch('DataObjectUtil/objectEditForm.tpl');
+	}
+
+	function getFormContentType($structure, $contentType = null) {
+		if ($contentType != null) {
+			return $contentType;
+		}
+		//Check to see if the request should be multipart/form-data
+		foreach ($structure as $property){
+			if ($property['type'] == 'section') {
+				$contentType = $this->getFormContentType($property['properties'], $contentType);
+			} else if ($property['type'] == 'image' || $property['type'] == 'file'){
+				$contentType = 'multipart/form-data';
+			}
+		}
+		return $contentType;
 	}
 
 	/**


### PR DESCRIPTION
If a form contains an input of type "file" the content type should be set accordingly. This commit ensures that the test for file type inputs is recursive through the form structure.