### PR TITLE
Force Hoopla Reload for 22.10.00 

### DIFF
--- a/code/web/release_notes/22.10.00.MD
+++ b/code/web/release_notes/22.10.00.MD
@@ -130,7 +130,7 @@
 - 650a and 655a fields now check for: "pop-up" for pop-up books (Ticket 85476)
 
 ###Other Updates
--Fix "Duplicate HooplaId" Error (Ticket 93619)
+-Fix "Duplicate HooplaId" Error and run Full Update for Hoopla (Ticket 93619)
 -Fixed a language issue that cause invalid grouped work ids to be created (Tickets 100476 & 104038)
 -Fixed an error bots were throwing with Prospector searches
 -Fixed an error when trying to place a hold on records that no longer exist

--- a/code/web/sys/DBMaintenance/version_updates/22.10.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/22.10.00.php
@@ -343,6 +343,13 @@ function getUpdates22_10_00(): array
 		], //add_account_display_options
 
 		//kodi
+        'force_reload_of_hoopla_22_10' => [
+            'title' => 'Force reload of Hoopla',
+            'description' => 'Force Hoopla to be reloaded for 22.10',
+            'sql' => [
+                "UPDATE hoopla_settings set runFullUpdate = 1",
+            ]
+        ], //force_reload_of_hoopla_22_10
 
 		//other
 


### PR DESCRIPTION
DB update to force reload of Hoopla records. Updated release notes
