### PR TITLE
SSO: Add definable entityId & XML metadata upload

### DIFF
--- a/code/web/cron/refreshSsoMetadata.php
+++ b/code/web/cron/refreshSsoMetadata.php
@@ -11,7 +11,7 @@ $library = new Library();
 $library->find();
 while ($library->fetch()){
     if (strlen($library->ssoXmlUrl) > 0) {
-        print "Refreshing metadata for $library->displayName\n";
+        print "Refreshing metadata for $library->displayName from $library->ssoXmlUrl\n";
         $result = $library->fetchAndStoreSsoMetadata();
         if ($result instanceof AspenError) {
             print "FAILED: " . $result->message . "\n";

--- a/code/web/interface/themes/responsive/MyAccount/ajax-login.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/ajax-login.tpl
@@ -69,11 +69,11 @@
 					</div>
 				</div>
 			{/if}
-			{if !(empty($ssoXmlUrl))}
+			{if !(empty($ssoEntityId))}
 			<div id="SAMLLoginRow" class="form-group">
 				<div class="col-xs-12 col-sm-offset-4 col-sm-8">
 					<p class="help-block">
-						<a href="/saml2auth.php?samlLogin=y&idp={$ssoXmlUrl}">Log in using {$ssoName}</a>
+						<a href="/saml2auth.php?samlLogin=y&idp={$ssoEntityId}">Log in using {$ssoName}</a>
 					</p>
 				</div>
 			</div>

--- a/code/web/interface/themes/responsive/MyAccount/login.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/login.tpl
@@ -75,11 +75,11 @@
 		                    </div>
 		                </div>
 		            {/if}
-		            {if !(empty($ssoXmlUrl))}
+		            {if !(empty($ssoEntityId))}
 		            <div id="SAMLLoginRow" class="form-group">
 		                <div class="col-xs-12 col-sm-offset-4 col-sm-8">
 		                    <p class="help-block">
-		                        <a href="/saml2auth.php?samlLogin=y&idp={$ssoXmlUrl}">Log in using {$ssoName}</a>
+		                        <a href="/saml2auth.php?samlLogin=y&idp={$ssoEntityId}">Log in using {$ssoName}</a>
 		                    </p>
 		                </div>
 		            </div>

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -959,8 +959,8 @@ class MyAccount_AJAX extends JSON_Action
 		$interface->assign('ssoLoginOptions', $loginOptions);
 
 		//SAML
-		if (!empty($library->ssoXmlUrl)) {
-			$interface->assign('ssoXmlUrl', $library->ssoXmlUrl);
+		if (!empty($library->ssoMetadataFilename) && !empty($library->ssoEntityId)) {
+			$interface->assign('ssoEntityId', $library->ssoEntityId);
 		}
 		$interface->assign('ssoName', isset($library->ssoName) ? $library->ssoName : 'single sign-on');
 

--- a/code/web/services/MyAccount/Login.php
+++ b/code/web/services/MyAccount/Login.php
@@ -98,8 +98,8 @@ class MyAccount_Login extends Action
 		$interface->assign('ssoLoginOptions', $loginOptions);
 
 		//SAML
-		if (isset($library->ssoXmlUrl)) {
-			$interface->assign('ssoXmlUrl', $library->ssoXmlUrl);
+		if (isset($library->ssoMetadataFilename) && isset($library->ssoEntityId)) {
+			$interface->assign('ssoEntityId', $library->ssoEntityId);
 		}
 		$interface->assign('ssoName', isset($library->ssoName) ? $library->ssoName : 'single sign-on');
 		if (!empty($library->loginNotes)) {

--- a/code/web/sys/Authentication/SSOSetting.php
+++ b/code/web/sys/Authentication/SSOSetting.php
@@ -31,6 +31,7 @@ class SSOSetting extends DataObject
 	public $ssoXmlUrl;
 	public $ssoUniqueAttribute;
 	public $ssoMetadataFilename;
+	public $ssoEntityId;
 	public $ssoIdAttr;
 	public $ssoUsernameAttr;
 	public $ssoFirstnameAttr;
@@ -95,6 +96,8 @@ class SSOSetting extends DataObject
 
 			'ssoName' => array('property' => 'ssoName', 'type' => 'text', 'label' => 'Name of service', 'description' => 'The name to be displayed when referring to the authentication service', 'size' => '512', 'hideInLists' => true, 'permissions' => ['Library ILS Connection']),
 			'ssoXmlUrl' => array('property' => 'ssoXmlUrl', 'type' => 'text', 'label' => 'URL of service metadata XML', 'description' => 'The URL at which the metadata XML document for this identity provider can be obtained', 'size' => '512', 'hideInLists' => true, 'permissions' => ['Library ILS Connection']),
+			'ssoMetadataFilename'=> array('path' => '/data/aspen-discovery/sso_metadata', 'property' => 'ssoMetadataFilename', 'type' => 'file', 'label' => 'XML metadata file', 'description' => 'The XML metadata file if no URL is available', 'serverValidation' => 'processXmlUpload', 'readOnly'=>true, 'permissions' => ['Library ILS Connection']),
+			'ssoEntityId' => array('property' => 'ssoEntityId', 'type' => 'text', 'label' => 'Entity ID of SSO provider', 'description' => 'The entity ID of the SSO IdP. This can be found in the IdP\'s metadata', 'size' => '512', 'hideInLists' => false, 'permissions' => ['Library ILS Connection']),
 			'ssoUniqueAttribute' => array('property' => 'ssoUniqueAttribute', 'type' => 'text', 'label' => 'Name of the identity provider attribute that uniquely identifies a user', 'description' => 'This should be unique to each user', 'size' => '512', 'hideInLists' => true, 'permissions' => ['Library ILS Connection']),
 			'ssoIdAttr' => array('property' => 'ssoIdAttr', 'type' => 'text', 'label' => 'Name of the identity provider attribute that contains the user ID', 'description' => 'This should be unique to each user', 'size' => '512', 'hideInLists' => true, 'permissions' => ['Library ILS Connection']),
 			'ssoUsernameAttr' => array('property' => 'ssoUsernameAttr', 'type' => 'text', 'label' => 'Name of the identity provider attribute that contains the user\'s username', 'description' => 'The user\'s username', 'size' => '512', 'hideInLists' => true, 'permissions' => ['Library ILS Connection']),

--- a/code/web/sys/DBMaintenance/version_updates/22.09.01.php
+++ b/code/web/sys/DBMaintenance/version_updates/22.09.01.php
@@ -1,0 +1,23 @@
+
+<?php
+/** @noinspection PhpUnused */
+function getUpdates22_09_01() : array
+{
+    $curTime = time();
+    return [
+		/*'name' => [
+			'title' => '',
+			'description' => '',
+			'sql' => [
+				''
+			]
+        ], //sample*/
+        'add_additional_library_sso_config_options' => [
+			'title' => 'SSO - Additional library config options',
+			'description' => 'Allow SSO configuration options to be specified',
+			'sql' => [
+				"ALTER TABLE library ADD column ssoEntityId VARCHAR(255)"
+            ]
+		] //add_library_sso_config_options
+	];
+}

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -274,8 +274,9 @@ class Library extends DataObject
 	//SSO
 	public /** @noinspection PhpUnused */ $ssoName;
 	public /** @noinspection PhpUnused */ $ssoXmlUrl;
-	public /** @noinspection PhpUnused */ $ssoUniqueAttribute;
 	public /** @noinspection PhpUnused */ $ssoMetadataFilename;
+	public /** @noinspection PhpUnused */ $ssoEntityId;
+	public /** @noinspection PhpUnused */ $ssoUniqueAttribute;
 	public /** @noinspection PhpUnused */ $ssoIdAttr;
 	public /** @noinspection PhpUnused */ $ssoUsernameAttr;
 	public /** @noinspection PhpUnused */ $ssoFirstnameAttr;
@@ -584,6 +585,8 @@ class Library extends DataObject
 			$validSelfRegistrationOptions[3] = 'Quipu eCARD';
 		}
 
+
+
 		/** @noinspection HtmlRequiredAltAttribute */
 		/** @noinspection RequiredAttributes */
 		$structure = array(
@@ -624,6 +627,8 @@ class Library extends DataObject
 			'ssoSection' => array('property'=>'ssoSection', 'type' => 'section', 'label' =>'Single Sign-on', 'hideInLists' => true, 'properties' => array(
 				'ssoName' => array('property'=>'ssoName', 'type'=>'text', 'label'=>'Name of service', 'description'=>'The name to be displayed when referring to the authentication service', 'size'=>'512', 'hideInLists' => false, 'permissions' => ['Library ILS Connection']),
 				'ssoXmlUrl' => array('property'=>'ssoXmlUrl', 'type'=>'text', 'label'=>'URL of service metadata XML', 'description'=>'The URL at which the metadata XML document for this identity provider can be obtained', 'size'=>'512', 'hideInLists' => false, 'permissions' => ['Library ILS Connection']),
+				'ssoMetadataFilename'=> array('path'=>'/data/aspen-discovery/sso_metadata', 'property'=>'ssoMetadataFilename', 'type'=>'file', 'label'=>'XML metadata file', 'description'=>'The XML metadata file if no URL is available', 'serverValidation'=>'processXmlUpload', 'readOnly'=>true, 'permissions' => ['Library ILS Connection']),
+				'ssoEntityId' => array('property'=>'ssoEntityId', 'type'=>'text', 'label'=>'Entity ID of SSO provider', 'description'=>'The entity ID of the SSO IdP. This can be found in the IdP\'s metadata', 'size'=>'512', 'hideInLists' => false, 'permissions' => ['Library ILS Connection']),
 				'ssoUniqueAttribute' => array('property'=>'ssoUniqueAttribute', 'type'=>'text', 'label'=>'Name of the identity provider attribute that uniquely identifies a user', 'description'=>'This should be unique to each user', 'size'=>'512', 'hideInLists' => false, 'permissions' => ['Library ILS Connection']),
 				'ssoIdAttr' => array('property'=>'ssoIdAttr', 'type'=>'text', 'label'=>'Name of the identity provider attribute that contains the user ID', 'description'=>'This should be unique to each user', 'size'=>'512', 'hideInLists' => false, 'permissions' => ['Library ILS Connection']),
 				'ssoUsernameAttr' => array('property'=>'ssoUsernameAttr', 'type'=>'text', 'label'=>'Name of the identity provider attribute that contains the user\'s username', 'description'=>'The user\'s username', 'size'=>'512', 'hideInLists' => false, 'permissions' => ['Library ILS Connection']),
@@ -1264,9 +1269,9 @@ class Library extends DataObject
 			'validatedOk' => true,
 			'errors' => array(),
 		);
-		// Only proceed if we have a populated SSO IdP URL (we infer SSO auth usage
-		// from this)
-		if (!$this->ssoXmlUrl || strlen($this->ssoXmlUrl) == 0) {
+		// Only validate everything else if we have a populated SSO entity ID
+		// (we infer SSO auth usage from this)
+		if (!$this->ssoEntityId || strlen($this->ssoEntityId) == 0) {
 			return $validationResults;
 		}
 		if (
@@ -1301,6 +1306,10 @@ class Library extends DataObject
 			'ssoCategoryIdAttr',
 			'ssoCategoryIdFallback',
 			'Single sign-on category ID: You must enter either an identity provider attribute name or fallback value'
+		);
+		$validationResults = array(
+			'validatedOk' => true,
+			'errors' => array(),
 		);
 	}
 
@@ -1907,9 +1916,7 @@ class Library extends DataObject
 		global $logger;
 		global $configArray;
 		global $serverName;
-		$dataPath = '/data/aspen-discovery/sso_metadata/';
-		$fileName = md5($serverName) . '.xml';
-		$filePath = $dataPath . $fileName;
+		$ssoXmlDataPath = '/data/aspen-discovery/sso_metadata/';
 		$url = trim($this->ssoXmlUrl);
 		if (strlen($url) > 0) {
 			// We've got a new or updated URL
@@ -1926,16 +1933,18 @@ class Library extends DataObject
 					$logger->log($e, Logger::LOG_ERROR);
 					return new AspenError('Unable to use SSO IdP metadata, please check "URL of service metadata XML"');
 				}
-				$written = file_put_contents($filePath, $xml);
+				$fileName = $serverName . '.xml';
+				$ssoMetadataFilename = $ssoXmlDataPath . $fileName;
+				$written = file_put_contents($ssoMetadataFilename, $xml);
 				if ($written === false) {
 					$logger->log(
-						'Failed to write SSO metadata to ' . $filePath . ' for site ' .
+						'Failed to write SSO metadata to ' . $ssoMetadataFilename . ' for site ' .
 						$configArray['Site']['title'],
 						Logger::LOG_ERROR
 					);
 					return new AspenError('Unable to use SSO IdP metadata, cannot create XML file');
 				} else {
-					chmod($filePath, 0764);
+					chmod($ssoMetadataFilename, 0764);
 				}
 			} else {
 				$logger->log(


### PR DESCRIPTION
This commit adds the following:
- Add the ability for the SSO admin to define the entityID for an IdP
- Add the ability to upload metadata as an XML file, this is in addition to the pre-existing ability to specify a URL that the metadata can be retrieved from