### PR TITLE
SSO: Add definable entityId & XML metadata upload

### DIFF
--- a/code/web/app/viewIdpMetadata.php
+++ b/code/web/app/viewIdpMetadata.php
@@ -8,14 +8,14 @@
 	$auth = new SAML2Authentication('/app/viewIdpMetadata.php');
 
 	// If we need to forward the user to an IdP
-	$url = $library->ssoXmlUrl;
+	$entityId = $library->ssoEntityId;
 	if (
 		array_key_exists('samlLogin', $_REQUEST) &&
 		array_key_exists('idp', $_REQUEST) &&
 		strlen($_REQUEST['samlLogin']) > 0 &&
 		strlen($_REQUEST['idp']) > 0 &&
-		$url &&
-		strlen($url) > 0
+		$entityId &&
+		strlen($entityId) > 0
 	) {
 		$auth->authenticate($_REQUEST['idp']);
 		header('Location: /');

--- a/code/web/cron/refreshSsoMetadata.php
+++ b/code/web/cron/refreshSsoMetadata.php
@@ -11,7 +11,7 @@ $library = new Library();
 $library->find();
 while ($library->fetch()){
     if (strlen($library->ssoXmlUrl) > 0) {
-        print "Refreshing metadata for $library->displayName\n";
+        print "Refreshing metadata for $library->displayName from $library->ssoXmlUrl\n";
         $result = $library->fetchAndStoreSsoMetadata();
         if ($result instanceof AspenError) {
             print "FAILED: " . $result->message . "\n";

--- a/code/web/interface/themes/responsive/MyAccount/ajax-login.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/ajax-login.tpl
@@ -69,11 +69,11 @@
 					</div>
 				</div>
 			{/if}
-			{if !(empty($ssoXmlUrl))}
+			{if !(empty($ssoEntityId))}
 			<div id="SAMLLoginRow" class="form-group">
 				<div class="col-xs-12 col-sm-offset-4 col-sm-8">
 					<p class="help-block">
-						<a href="/saml2auth.php?samlLogin=y&idp={$ssoXmlUrl}">Log in using {$ssoName}</a>
+						<a href="/saml2auth.php?samlLogin=y&idp={$ssoEntityId}">Log in using {$ssoName}</a>
 					</p>
 				</div>
 			</div>

--- a/code/web/interface/themes/responsive/MyAccount/login.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/login.tpl
@@ -75,11 +75,11 @@
 		                    </div>
 		                </div>
 		            {/if}
-		            {if !(empty($ssoXmlUrl))}
+		            {if !(empty($ssoEntityId))}
 		            <div id="SAMLLoginRow" class="form-group">
 		                <div class="col-xs-12 col-sm-offset-4 col-sm-8">
 		                    <p class="help-block">
-		                        <a href="/saml2auth.php?samlLogin=y&idp={$ssoXmlUrl}">Log in using {$ssoName}</a>
+		                        <a href="/saml2auth.php?samlLogin=y&idp={$ssoEntityId}">Log in using {$ssoName}</a>
 		                    </p>
 		                </div>
 		            </div>

--- a/code/web/saml2auth.php
+++ b/code/web/saml2auth.php
@@ -9,14 +9,14 @@
 	$auth = new SAML2Authentication();
 
 	// If we need to forward the user to an IdP
-	$url = $library->ssoXmlUrl;
+	$entityId = $library->ssoEntityId;
 	if (
 		array_key_exists('samlLogin', $_REQUEST) &&
 		array_key_exists('idp', $_REQUEST) &&
 		strlen($_REQUEST['samlLogin']) > 0 &&
 		strlen($_REQUEST['idp']) > 0 &&
-		$url &&
-		strlen($url) > 0
+		$entityId &&
+		strlen($entityId) > 0
 	) {
 		$auth->authenticate($_REQUEST['idp']);
 		header('Location: /');

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -959,8 +959,8 @@ class MyAccount_AJAX extends JSON_Action
 		$interface->assign('ssoLoginOptions', $loginOptions);
 
 		//SAML
-		if (!empty($library->ssoXmlUrl)) {
-			$interface->assign('ssoXmlUrl', $library->ssoXmlUrl);
+		if (!empty($library->ssoMetadataFilename) && !empty($library->ssoEntityId)) {
+			$interface->assign('ssoEntityId', $library->ssoEntityId);
 		}
 		$interface->assign('ssoName', isset($library->ssoName) ? $library->ssoName : 'single sign-on');
 

--- a/code/web/services/MyAccount/Login.php
+++ b/code/web/services/MyAccount/Login.php
@@ -98,8 +98,8 @@ class MyAccount_Login extends Action
 		$interface->assign('ssoLoginOptions', $loginOptions);
 
 		//SAML
-		if (isset($library->ssoXmlUrl)) {
-			$interface->assign('ssoXmlUrl', $library->ssoXmlUrl);
+		if (isset($library->ssoMetadataFilename) && isset($library->ssoEntityId)) {
+			$interface->assign('ssoEntityId', $library->ssoEntityId);
 		}
 		$interface->assign('ssoName', isset($library->ssoName) ? $library->ssoName : 'single sign-on');
 		if (!empty($library->loginNotes)) {

--- a/code/web/sys/Authentication/SSOSetting.php
+++ b/code/web/sys/Authentication/SSOSetting.php
@@ -31,6 +31,7 @@ class SSOSetting extends DataObject
 	public $ssoXmlUrl;
 	public $ssoUniqueAttribute;
 	public $ssoMetadataFilename;
+	public $ssoEntityId;
 	public $ssoIdAttr;
 	public $ssoUsernameAttr;
 	public $ssoFirstnameAttr;
@@ -95,6 +96,8 @@ class SSOSetting extends DataObject
 
 			'ssoName' => array('property' => 'ssoName', 'type' => 'text', 'label' => 'Name of service', 'description' => 'The name to be displayed when referring to the authentication service', 'size' => '512', 'hideInLists' => true, 'permissions' => ['Library ILS Connection']),
 			'ssoXmlUrl' => array('property' => 'ssoXmlUrl', 'type' => 'text', 'label' => 'URL of service metadata XML', 'description' => 'The URL at which the metadata XML document for this identity provider can be obtained', 'size' => '512', 'hideInLists' => true, 'permissions' => ['Library ILS Connection']),
+			'ssoMetadataFilename'=> array('path' => '/data/aspen-discovery/sso_metadata', 'property' => 'ssoMetadataFilename', 'type' => 'file', 'label' => 'XML metadata file', 'description' => 'The XML metadata file if no URL is available', 'readOnly'=>true, 'permissions' => ['Library ILS Connection']),
+			'ssoEntityId' => array('property' => 'ssoEntityId', 'type' => 'text', 'label' => 'Entity ID of SSO provider', 'description' => 'The entity ID of the SSO IdP. This can be found in the IdP\'s metadata', 'size' => '512', 'hideInLists' => false, 'permissions' => ['Library ILS Connection']),
 			'ssoUniqueAttribute' => array('property' => 'ssoUniqueAttribute', 'type' => 'text', 'label' => 'Name of the identity provider attribute that uniquely identifies a user', 'description' => 'This should be unique to each user', 'size' => '512', 'hideInLists' => true, 'permissions' => ['Library ILS Connection']),
 			'ssoIdAttr' => array('property' => 'ssoIdAttr', 'type' => 'text', 'label' => 'Name of the identity provider attribute that contains the user ID', 'description' => 'This should be unique to each user', 'size' => '512', 'hideInLists' => true, 'permissions' => ['Library ILS Connection']),
 			'ssoUsernameAttr' => array('property' => 'ssoUsernameAttr', 'type' => 'text', 'label' => 'Name of the identity provider attribute that contains the user\'s username', 'description' => 'The user\'s username', 'size' => '512', 'hideInLists' => true, 'permissions' => ['Library ILS Connection']),

--- a/code/web/sys/DBMaintenance/version_updates/22.09.01.php
+++ b/code/web/sys/DBMaintenance/version_updates/22.09.01.php
@@ -1,0 +1,23 @@
+
+<?php
+/** @noinspection PhpUnused */
+function getUpdates22_09_01() : array
+{
+    $curTime = time();
+    return [
+		/*'name' => [
+			'title' => '',
+			'description' => '',
+			'sql' => [
+				''
+			]
+        ], //sample*/
+        'add_additional_library_sso_config_options' => [
+			'title' => 'SSO - Additional library config options',
+			'description' => 'Allow SSO configuration options to be specified',
+			'sql' => [
+				"ALTER TABLE library ADD column ssoEntityId VARCHAR(255)"
+            ]
+		] //add_library_sso_config_options
+	];
+}

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -274,8 +274,9 @@ class Library extends DataObject
 	//SSO
 	public /** @noinspection PhpUnused */ $ssoName;
 	public /** @noinspection PhpUnused */ $ssoXmlUrl;
-	public /** @noinspection PhpUnused */ $ssoUniqueAttribute;
 	public /** @noinspection PhpUnused */ $ssoMetadataFilename;
+	public /** @noinspection PhpUnused */ $ssoEntityId;
+	public /** @noinspection PhpUnused */ $ssoUniqueAttribute;
 	public /** @noinspection PhpUnused */ $ssoIdAttr;
 	public /** @noinspection PhpUnused */ $ssoUsernameAttr;
 	public /** @noinspection PhpUnused */ $ssoFirstnameAttr;
@@ -584,6 +585,8 @@ class Library extends DataObject
 			$validSelfRegistrationOptions[3] = 'Quipu eCARD';
 		}
 
+
+
 		/** @noinspection HtmlRequiredAltAttribute */
 		/** @noinspection RequiredAttributes */
 		$structure = array(
@@ -624,6 +627,8 @@ class Library extends DataObject
 			'ssoSection' => array('property'=>'ssoSection', 'type' => 'section', 'label' =>'Single Sign-on', 'hideInLists' => true, 'properties' => array(
 				'ssoName' => array('property'=>'ssoName', 'type'=>'text', 'label'=>'Name of service', 'description'=>'The name to be displayed when referring to the authentication service', 'size'=>'512', 'hideInLists' => false, 'permissions' => ['Library ILS Connection']),
 				'ssoXmlUrl' => array('property'=>'ssoXmlUrl', 'type'=>'text', 'label'=>'URL of service metadata XML', 'description'=>'The URL at which the metadata XML document for this identity provider can be obtained', 'size'=>'512', 'hideInLists' => false, 'permissions' => ['Library ILS Connection']),
+				'ssoMetadataFilename'=> array('path'=>'/data/aspen-discovery/sso_metadata', 'property'=>'ssoMetadataFilename', 'type'=>'file', 'label'=>'XML metadata file', 'description'=>'The XML metadata file if no URL is available', 'readOnly'=>true, 'permissions' => ['Library ILS Connection']),
+				'ssoEntityId' => array('property'=>'ssoEntityId', 'type'=>'text', 'label'=>'Entity ID of SSO provider', 'description'=>'The entity ID of the SSO IdP. This can be found in the IdP\'s metadata', 'size'=>'512', 'hideInLists' => false, 'permissions' => ['Library ILS Connection']),
 				'ssoUniqueAttribute' => array('property'=>'ssoUniqueAttribute', 'type'=>'text', 'label'=>'Name of the identity provider attribute that uniquely identifies a user', 'description'=>'This should be unique to each user', 'size'=>'512', 'hideInLists' => false, 'permissions' => ['Library ILS Connection']),
 				'ssoIdAttr' => array('property'=>'ssoIdAttr', 'type'=>'text', 'label'=>'Name of the identity provider attribute that contains the user ID', 'description'=>'This should be unique to each user', 'size'=>'512', 'hideInLists' => false, 'permissions' => ['Library ILS Connection']),
 				'ssoUsernameAttr' => array('property'=>'ssoUsernameAttr', 'type'=>'text', 'label'=>'Name of the identity provider attribute that contains the user\'s username', 'description'=>'The user\'s username', 'size'=>'512', 'hideInLists' => false, 'permissions' => ['Library ILS Connection']),
@@ -1264,9 +1269,9 @@ class Library extends DataObject
 			'validatedOk' => true,
 			'errors' => array(),
 		);
-		// Only proceed if we have a populated SSO IdP URL (we infer SSO auth usage
-		// from this)
-		if (!$this->ssoXmlUrl || strlen($this->ssoXmlUrl) == 0) {
+		// Only validate everything else if we have a populated SSO entity ID
+		// (we infer SSO auth usage from this)
+		if (!$this->ssoEntityId || strlen($this->ssoEntityId) == 0) {
 			return $validationResults;
 		}
 		if (
@@ -1301,6 +1306,10 @@ class Library extends DataObject
 			'ssoCategoryIdAttr',
 			'ssoCategoryIdFallback',
 			'Single sign-on category ID: You must enter either an identity provider attribute name or fallback value'
+		);
+		$validationResults = array(
+			'validatedOk' => true,
+			'errors' => array(),
 		);
 	}
 
@@ -1907,9 +1916,7 @@ class Library extends DataObject
 		global $logger;
 		global $configArray;
 		global $serverName;
-		$dataPath = '/data/aspen-discovery/sso_metadata/';
-		$fileName = md5($serverName) . '.xml';
-		$filePath = $dataPath . $fileName;
+		$ssoXmlDataPath = '/data/aspen-discovery/sso_metadata/';
 		$url = trim($this->ssoXmlUrl);
 		if (strlen($url) > 0) {
 			// We've got a new or updated URL
@@ -1926,16 +1933,18 @@ class Library extends DataObject
 					$logger->log($e, Logger::LOG_ERROR);
 					return new AspenError('Unable to use SSO IdP metadata, please check "URL of service metadata XML"');
 				}
-				$written = file_put_contents($filePath, $xml);
+				$fileName = $serverName . '.xml';
+				$ssoMetadataFilename = $ssoXmlDataPath . $fileName;
+				$written = file_put_contents($ssoMetadataFilename, $xml);
 				if ($written === false) {
 					$logger->log(
-						'Failed to write SSO metadata to ' . $filePath . ' for site ' .
+						'Failed to write SSO metadata to ' . $ssoMetadataFilename . ' for site ' .
 						$configArray['Site']['title'],
 						Logger::LOG_ERROR
 					);
 					return new AspenError('Unable to use SSO IdP metadata, cannot create XML file');
 				} else {
-					chmod($filePath, 0764);
+					chmod($ssoMetadataFilename, 0764);
 				}
 			} else {
 				$logger->log(

--- a/sites/ptfse.dev/conf/config.cron.ini
+++ b/sites/ptfse.dev/conf/config.cron.ini
@@ -1,0 +1,43 @@
+# Configures the processes that cron will run when it is invoked with
+# additional information about the frequency that it is invoked.
+# The ini file should have a Processes section with the name of each process to run
+#
+# Processes should have the format:
+#  - Process Name = Process Handler Class
+#
+# Each process will also have a section based on the Process Name.
+# the section should contain the following keys at a minimum
+# - description = A brief description of what the process does
+# - lastRun = the timestamp the process was last run.  Blank if the process has never been run.
+# - frequencyHours = the frequency with which the process should be run in hours or 0 if it should be run each time cron runs.
+#
+# General settings can also be defined that will be sent to all processes.
+# these can include database connection information, solr settings, etc.
+
+[Processes]
+UpdateReadingHistory = com.turning_leaf_technologies.cron.reading_history.UpdateReadingHistory
+BookCoverCleanup = com.turning_leaf_technologies.cron.BookCoverCleanup
+DatabaseCleanup = com.turning_leaf_technologies.cron.DatabaseCleanup
+GenealogyCleanup = com.turning_leaf_technologies.cron.genealogy.GenealogyCleanup
+
+[UpdateReadingHistory]
+description = Updates reading History for the patron based on what is currently checked out.
+frequencyHours = 0
+
+[BookCoverCleanup]
+description = Cleans up any book covers that are out of date (more than 2 weeks old).
+frequencyHours = 0
+
+[DatabaseCleanup]
+description = Does cleanup of the database to remove records that are no longer needed
+frequencyHours = 0
+
+[GenealogyCleanup]
+description = Does cleanup with an option to reindex all people
+frequencyHours = -1
+deleteDuplicates = false
+reindex = true
+genealogyIndex = http://localhost:8080/solr/genealogy
+
+
+

--- a/sites/ptfse.dev/conf/config.ini
+++ b/sites/ptfse.dev/conf/config.ini
@@ -1,0 +1,40 @@
+;
+; default config file for customization
+; Aspen Discovery Configuration
+;
+
+; No changes are necessary in the System Section
+[System]
+debug           = true
+timings         = false
+debugJs         = true
+operatingSystem = linux
+
+; This section will need to be customized for your installation
+[Site]
+local           = /usr/local/aspen-discovery/code/web
+coverPath       = /data/aspen-discovery/ptfse.dev/covers
+url             = http://dev.aspendiscovery.co.uk
+title           = "PTFS-E Dev"
+libraryName     = PTFS-E Dev
+; Find valid timezone values here:
+;   http://www.php.net/manual/en/timezones.php
+timezone        = "Europe/London"
+
+[Catalog]
+ils                  = Koha
+driver               = Koha
+showFines            = true
+barcodeProperty      = cat_username
+url                  = https://support.koha-ptfs.co.uk
+linking_url          = https://support.koha-ptfs.co.uk
+staffClientUrl       = https://support-staff.koha-ptfs.co.uk
+
+; This section requires no changes for most installations
+[Index]
+url             = http://127.0.0.1:8080/solr
+
+[Reindex]
+solrPort             = 8080
+marcPath             = /data/aspen-discovery/ptfse.dev/ils/marc
+lexileExportPath     = /data/aspen-discovery/lexileTitles.txt

--- a/sites/ptfse.dev/conf/crontab_settings.txt
+++ b/sites/ptfse.dev/conf/crontab_settings.txt
@@ -1,0 +1,70 @@
+##################
+## Crontab setting from a 'configuration' file
+##
+## crontab for the site should be linked to from /etc/cron.d
+## when updated, cron simply needs to be restarted.  I.e.
+## sudo service crond restart
+##
+##################
+
+###################
+# * * * * *  command to execute
+# │ │ │ │ │
+# │ │ │ │ └───── day of week (0 - 6)
+# │ │ │ │        (0 to 6 are Sunday to Saturday, or use names (Sun,Mon,Tue,Wed,Thu,Fri,Sat); 7 is Sunday, the same as 0)
+# │ │ │ └────────── month (1 - 12)
+# │ │ └─────────────── day of month (1 - 31)
+# │ └──────────────────── hour (0 - 23)
+# └───────────────────────── min (0 - 59)
+## taken from https://en.wikipedia.org/wiki/Cron
+##############
+
+#############
+# Indexing Tasks #
+#############
+@reboot       solr    php /usr/local/aspen-discovery/code/web/cron/checkSolr.php ptfse.dev
+5 2 * * *     solr   php /usr/local/aspen-discovery/code/web/cron/updateSuggesters.php ptfse.dev
+7 3 * * *     aspen   php /usr/local/aspen-discovery/code/web/cron/createSitemaps.php ptfse.dev
+*/2 * * * *   solr    php /usr/local/aspen-discovery/code/web/cron/checkSolr.php ptfse.dev
+*/5 * * * *   aspen   php /usr/local/aspen-discovery/code/web/cron/checkBackgroundProcesses.php ptfse.dev
+
+########################################################
+# Regular extracts that don't need to run continuously #
+########################################################
+0 2 * * *     aspen   cd /usr/local/aspen-discovery/code/oai_indexer; java -jar oai_indexer.jar ptfse.dev
+0 2 * * *     aspen   cd /usr/local/aspen-discovery/code/reindexer; java -jar reindexer.jar ptfse.dev nightly
+
+######################
+# MySQL Nightly Dump #
+######################
+# backup important bits at 12:10am daily
+10 0 * * *    root    /usr/local/aspen-discovery/code/cron/nightly_mysql_dump.sh ptfse.dev aspen 2>&1 >/dev/null
+
+#############################################
+# New York Times Best seller Lists Updating #
+#############################################
+15 7 * * 0-1  aspen   php /usr/local/aspen-discovery/code/web/cron/updateNYTLists.php ptfse.dev
+# update on Sundays and Mondays at 7:15
+
+###########################
+# Aspen Discovery Cleanup #
+###########################
+
+# Temp files
+26 0 * * *    root    cd /tmp; rm -rf CURLCOOKIE*
+
+# CRON for Aspen (book cover cache cleanup etc.)
+00 22 * * *   aspen   cd /usr/local/aspen-discovery/code/cron; java -jar cron.jar ptfse.dev
+
+00 01 * * *   root    certbot renew
+
+############################
+# Fix Cover Permissions    #
+############################
+*/15 * * * * root chown aspen:aspen_apache /data/aspen-discovery/ptfse.dev/covers/original/*
+*/15 * * * * root chmod g+rw /data/aspen-discovery/ptfse.dev/covers/original/*
+
+#############################
+# Refresh SAML SSO metadata #
+#############################
+00 05  * * * www-data php /usr/local/aspen-discovery/code/web/cron/refreshSsoMetadata.php ptfse.dev

--- a/sites/ptfse.dev/httpd-ptfse.dev.conf
+++ b/sites/ptfse.dev/httpd-ptfse.dev.conf
@@ -1,0 +1,100 @@
+<VirtualHost *:443>
+    <IfModule mod_rewrite.c>
+		RewriteEngine On
+	</IfModule>
+	ServerName dev.aspendiscovery.co.uk
+	DocumentRoot "/usr/local/aspen-discovery/code/web"
+	CustomLog /var/log/aspen-discovery/ptfse.dev/access.log combined
+	ErrorLog /var/log/aspen-discovery/ptfse.dev/error.log
+	ErrorDocument 404 /Error/Handle404
+
+	<Directory /usr/local/aspen-discovery/code/web/>
+		Require all granted
+		Options -Indexes -MultiViews
+		AllowOverride All
+
+		SetEnv aspen_server ptfse.dev
+
+		# Friendly URLs
+		<IfModule mod_rewrite.c>
+			RewriteEngine	On
+			RewriteRule  ^robots\.txt$ /robots.php [NC,L]
+			RewriteRule  ^sitemapindex\.xml$ /sitemapindex.php [NC,L]
+			RewriteRule  ^grouped_work_site_map(.+)$ /sitemaps/grouped_work_site_map$1 [NC,L]
+
+			# Note: The following RewriteRule directives include the [B] flag to escape
+			# backreferences.  This prevents encoding problems caused by special characters
+			# like & if they show up in ids.  Note that the flag doesn't work in some
+			# versions of Apache prior to 2.2.12; if you run into trouble, try upgrading.
+			RewriteRule   ^(MyAccount)/([^/]+)/(.+)$   index.php?module=$1&action=$2&id=$3   [B,L,QSA]
+			RewriteRule   ^(Record)/([^/]+)/(.+)$       index.php?module=$1&id=$2&action=$3   [B,L,QSA]
+			RewriteRule   ^(Record)/(.+)$               index.php?module=$1&id=$2             [B,L,QSA]
+			RewriteRule   ^([^/]+)/(.+)$                index.php?module=$1&action=$2         [B,L,QSA]
+		</IfModule>
+
+		# Disable Magic Quotes
+		php_value magic_quotes_gpc false
+
+		# Session Settings
+		php_value session.use_cookies  1
+		php_value session.use_only_cookies 1
+		# important: we want to serialize objects
+		php_value session.auto_start 0
+		#php_value session.cookie_secure 1
+		# we should check session lifetime in "read" methods
+		# since PHP cookies do not "refresh" them during activity
+		# hence we leave them alive until browser closes
+		php_value session.cookie_lifetime  0
+		php_value session.gc_maxlifetime 6000
+
+		## Uncomment these lines if you wish to show all errors on the screen.
+		#php_value display_errors 1
+		#php_value error_reporting 2047
+
+		# enable expirations
+		<IfModule mod_expires.c>
+		  ExpiresActive On
+		  ExpiresByType image/gif "access plus 1 month"
+		  ExpiresByType image/png "access plus 1 month"
+		  ExpiresByType image/jpg "access plus 1 month"
+		  ExpiresByType image/jpeg "access plus 1 month"
+		  ExpiresByType image/x-icon "access plus 1 month"
+		  ExpiresByType text/css "access plus 2 weeks"
+		  ExpiresByType application/javascript "access plus 2 weeks"
+		</IfModule>
+
+		#Enable deflating (gzip) of content
+		<IfModule mod_deflate.c>
+			# Insert filter
+			SetOutputFilter DEFLATE
+
+			# Netscape 4.x has some problems...
+			BrowserMatch ^Mozilla/4 gzip-only-text/html
+
+			# Netscape 4.06-4.08 have some more problems
+			BrowserMatch ^Mozilla/4\.0[678] no-gzip
+
+			# MSIE masquerades as Netscape, but it is fine
+			# BrowserMatch \bMSIE !no-gzip !gzip-only-text/html
+
+			# NOTE: Due to a bug in mod_setenvif up to Apache 2.0.48
+			# the above regex won't work. You can use the following
+			# workaround to get the desired effect:
+			BrowserMatch \bMSI[E] !no-gzip !gzip-only-text/html
+
+			# Don't compress images
+			SetEnvIfNoCase Request_URI \
+			\.(?:gif|jpe?g|png)$ no-gzip dont-vary
+		</IfModule>
+	</Directory>
+
+        # SimpleSAMLphp
+        Alias /sso /usr/share/simplesamlphp/www
+        <Directory /usr/share/simplesamlphp/www/>
+                Require all granted
+        </Directory>
+
+	SSLEngine on
+	SSLCertificateFile /etc/letsencrypt/live/dev.aspendiscovery.co.uk/fullchain.pem
+	SSLCertificateKeyFile /etc/letsencrypt/live/dev.aspendiscovery.co.uk/privkey.pem
+</VirtualHost>

--- a/sites/ptfse.dev/ptfse.dev.sh
+++ b/sites/ptfse.dev/ptfse.dev.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ -z "$1" ]
+  then
+    echo "To use, run with start, stop or restart for the first parameter."
+fi
+
+if [[ ( "$1" == "stop" ) || ( "$1" == "restart") ]]
+  then
+    /usr/local/aspen-discovery/sites/default/solr-7.6.0/bin/solr stop -p 8080 -s "/data/aspen-discovery/ptfse.dev/solr7" -d "/usr/local/aspen-discovery/sites/default/solr-7.6.0/server"
+fi
+
+if [[ ( "$1" == "start" ) || ( "$1" == "restart") ]]
+  then
+    /usr/local/aspen-discovery/sites/default/solr-7.6.0/bin/solr start -m 3g -p 8080 -s "/data/aspen-discovery/ptfse.dev/solr7" -d "/usr/local/aspen-discovery/sites/default/solr-7.6.0/server"
+fi


### PR DESCRIPTION
This commit adds the following:
- Add the ability for the SSO admin to define the entityID for an IdP
- Add the ability to upload metadata as an XML file, this is in addition to the pre-existing ability to specify a URL that the metadata can be retrieved from