### PR TITLE
Primary Format Fix for Indexing by Item Record

### DIFF
--- a/code/reindexer/src/com/turning_leaf_technologies/reindexer/RecordInfo.java
+++ b/code/reindexer/src/com/turning_leaf_technologies/reindexer/RecordInfo.java
@@ -123,24 +123,32 @@ public class RecordInfo {
 	String getPrimaryFormat() {
 		if (primaryFormat == null){
 			HashMap<String, Integer> relatedFormats = new HashMap<>();
-			for (String format : formats){
-				relatedFormats.put(format, 1);
-			}
 			HashMap<String, String> formatToFormatCategory = new HashMap<>();
 			for (ItemInfo curItem : relatedItems){
 				if (curItem.getFormat() != null && !curItem.getFormat().equals("")) {
-					relatedFormats.put(curItem.getFormat(), relatedFormats.getOrDefault(curItem.getFormat(), 1));
+					if (relatedFormats.containsKey(curItem.getFormat())){
+						relatedFormats.merge(curItem.getFormat(), 1, Integer::sum);
+					}else{
+						relatedFormats.put(curItem.getFormat(), relatedFormats.getOrDefault(curItem.getFormat(), 1));
+					}
 					formatToFormatCategory.put(curItem.getFormat(), curItem.getFormatCategory());
 				}
 			}
-			int timesUsed = 0;
-			String mostUsedFormat = null;
-			for (String curFormat : relatedFormats.keySet()){
-				if (relatedFormats.get(curFormat) > timesUsed){
-					mostUsedFormat = curFormat;
-					timesUsed = relatedFormats.get(curFormat);
+
+			HashMap.Entry<String, Integer> FormatCounter = null; 	//need to sort through both string and integer to compare things properly
+			String mostUsedFormat = null; 			//Set most used format to null before iterating through the hashmap
+
+			//for each entry set in relatedFormats
+			for (HashMap.Entry<String, Integer> curItem : relatedFormats.entrySet())
+			{
+				//if current item format count is greater than FormatCounter, set this as mostUsedFormat
+				if (FormatCounter == null || curItem.getValue().compareTo(FormatCounter.getValue()) > 0)
+				{
+					FormatCounter = curItem;
+					mostUsedFormat = curItem.getKey(); //get and set the most used format from entrySet with getKey()
 				}
 			}
+
 			if (mostUsedFormat == null){
 				return "Unknown";
 			}else{

--- a/code/web/release_notes/22.10.00.MD
+++ b/code/web/release_notes/22.10.00.MD
@@ -35,6 +35,7 @@
 - Look at 490 field for series information if not found in the 830 or 800 field.
 - Allow processing of links between records using the 773 field. 
 - Upgrade MySQL connector to latest version.
+- Fixed an issue where Primary Format, when indexing by item records, wasn't being calculated properly
 
 ### Interface Updates
 


### PR DESCRIPTION
Fixed an issue where the value in HashMap relatedFormats was always set to 1 regardless of how many times a format appeared in an item record. Changed logic to calculate mostUsedFormat by comparing values in relatedFormats HashMap. Tested successfully on dev environment with no errors. Updated release notes