### PR TITLE
Updates to title_display/displayTitle

### DIFF
--- a/code/reindexer/src/com/turning_leaf_technologies/reindexer/AbstractGroupedWorkSolr.java
+++ b/code/reindexer/src/com/turning_leaf_technologies/reindexer/AbstractGroupedWorkSolr.java
@@ -466,27 +466,18 @@ public abstract class AbstractGroupedWorkSolr {
 				//remove punctuation from the sortable title
 				sortableTitle = punctuationPattern.matcher(sortableTitle).replaceAll("");
 				this.titleSort = sortableTitle.trim();
-				displayTitle = AspenStringUtils.trimTrailingPunctuation(displayTitle);
-				//Strip out anything in brackets unless that would cause us to show nothing
-				tmpTitle = removeBracketsPattern.matcher(displayTitle).replaceAll("").trim();
-				if (tmpTitle.length() > 0) {
-					displayTitle = tmpTitle;
-				}
-				//Remove common formats
-				tmpTitle = commonSubtitlePattern.matcher(displayTitle).replaceAll("").trim();
-				if (tmpTitle.length() > 0) {
-					displayTitle = tmpTitle;
-				}
-				this.displayTitle = displayTitle.trim();
 
 				//SubTitle only gets set based on the main title.
 				if (subTitle == null){
+					this.displayTitle = shortTitle;
 					if (this.subTitle != null) {
 						//clear the subtitle if it was set by a previous record.
 						this.subTitle = null;
 					}
 				}else {
 					setSubTitle(subTitle);
+					subTitle = AspenStringUtils.trimTrailingPunctuation(subTitle);
+					this.displayTitle = shortTitle.concat(": ").concat(subTitle);
 				}
 			}
 


### PR DESCRIPTION
Fix for LiDA title displays - API calls check display_title. Now use short title if no subtitle and concat short and sub titles if subtitle exists. Were previously using sortableTitle since it was set to tmpTitle before displayTitle. removed some redundancy (removal of common formats and punctuation is done for short and sub title).