### PR TITLE
Format Updates

### DIFF
--- a/code/reindexer/src/com/turning_leaf_technologies/reindexer/MarcRecordProcessor.java
+++ b/code/reindexer/src/com/turning_leaf_technologies/reindexer/MarcRecordProcessor.java
@@ -1328,6 +1328,21 @@ abstract class MarcRecordProcessor {
 			printFormats.add("VoxBooks");
 			return;
 		}
+		if (printFormats.contains("Playaway Launchpad")){
+			printFormats.clear();
+			printFormats.add("Playaway Launchpad");
+			return;
+		}
+		if (printFormats.contains("Playaway Bookpack")){
+			printFormats.clear();
+			printFormats.add("Playaway Bookpack");
+			return;
+		}
+		if (printFormats.contains("PlayawayView")){
+			printFormats.clear();
+			printFormats.add("PlayawayView");
+			return;
+		}
 		if (printFormats.contains("Wonderbook")){
 			printFormats.clear();
 			printFormats.add("Wonderbook");
@@ -1353,9 +1368,18 @@ abstract class MarcRecordProcessor {
 		if (printFormats.contains("DVD")){
 			printFormats.remove("VideoCassette");
 		}
+		if (printFormats.contains("4K Blu-ray")){
+			printFormats.remove("VideoDisc");
+			printFormats.remove("DVD");
+			printFormats.remove("Blu-ray");
+		}
 		if (printFormats.contains("Blu-ray")){
 			printFormats.remove("VideoDisc");
 			printFormats.remove("DVD");
+		}
+		if (printFormats.contains("4K/Blu-ray")){
+			printFormats.remove("Blu-ray");
+			printFormats.remove("4K Blu-ray");
 		}
 		if (printFormats.contains("Blu-ray/DVD")){
 			printFormats.remove("Blu-ray");


### PR DESCRIPTION
Added checks to remove/add formats as necessary for 4K Blu-rays, 4K/Blu-ray combos, Playaway Views, Playaway Launchpads, and Playaway Bookpacks. Without these, the formats were defaulting to either simply "Blu-ray" or "Playaway"