### PR TITLE
gUnzip and copy summary

### DIFF
--- a/code/java_shared_libraries/src/com/turning_leaf_technologies/file/UnzipUtility.java
+++ b/code/java_shared_libraries/src/com/turning_leaf_technologies/file/UnzipUtility.java
@@ -7,6 +7,10 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.zip.GZIPInputStream;
 
 /**
  * This utility extracts files and directories of a standard zip file to
@@ -63,5 +67,20 @@ public class UnzipUtility {
             bos.write(bytesIn, 0, read);
         }
         bos.close();
+    }
+
+    //gUnzip is currently not utilized and needs testing when applicable
+    public static void gUnzip(Path source, Path target) throws IOException {
+        try (GZIPInputStream gis = new GZIPInputStream(new FileInputStream(source.toFile()));
+             FileOutputStream fos = new FileOutputStream(target.toFile())) {
+            // copy GZIPInputStream to FileOutputStream
+            byte[] buffer = new byte[BUFFER_SIZE];
+            int read = 0;
+            while ((read = gis.read(buffer)) != -1) {
+                fos.write(buffer, 0, read);
+            }
+            fos.close();
+            gis.close();
+        }
     }
 }

--- a/code/web/interface/themes/responsive/GroupedWork/copySummary.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/copySummary.tpl
@@ -14,15 +14,13 @@
 			{if $item.displayByDefault && $numRowsShown<3}
 				{if $item.isEContent == false}
 					<div class="itemSummary row" style="margin: 0">
-						<div class="col-lg-7">
+						<div class="col-lg-12">
 							<span class="notranslate">{if !$item.isEContent}<strong>{$item.shelfLocation}</strong>{/if}
-								{if $item.availableCopies < 999}
-									&nbsp; {translate text="%1% available" 1=$item.availableCopies isPublicFacing=true}
+							<br>{$item.callNumber}
+								<br>{if $item.availableCopies < 999}
+									{translate text="%1% available" 1=$item.availableCopies isPublicFacing=true}
 								{/if}
 							</span>
-						</div>
-						<div class="col-lg-4">
-								<span class="notranslate"><strong>{$item.callNumber}</strong></span>
 						</div>
 					</div>
 				{/if}

--- a/code/web/release_notes/22.11.00.MD
+++ b/code/web/release_notes/22.11.00.MD
@@ -19,6 +19,7 @@
 - Ensure translation maps are closed after loading them.
 - When using item based format mapping and the item level format has been cleared to force bib level evaluation use the original value for the format if the bib format is the same as the item.
 - When converting MARC records to JSON and storing in the database remove any tags that are not numeric and properly escape marc indicators. 
+- Hide the series label if the 490 field is an empty string
 
 ###Koha Updates
 - Manual renewals now honor OPACFineNoRenewals and OPACFineNoRenewalsIncludeCredits system preferences. (Ticket 104948)
@@ -41,7 +42,11 @@
 - When clearing bib data in Greenhouse, force appropriate indexes to run again.
 - When placing a hold only update the preferred pickup location if "Always use this pickup location" is checked.
 - Update opacity of covers shown within title scrollers. 
-- Additional logging when there are errors updating the memory cache. 
+- Additional logging when there are errors updating the memory cache.
+- Fixed an issue where browse category shifts if display is set to Grid (Ticket 102046)
+- Fixed an issue where the format category filter was displaying incorrect values in the Advanced Search (Ticket 105365)
+- Fixed an issue where the display title wasn't displaying correctly in LiDA (Ticket 103649)
+- Updated UI to show copy summary information in search results in one column instead of two (Ticket 100367)
 
 ###This release includes code contributions from:
 - ByWater Solutions


### PR DESCRIPTION
Added function for gUnzip. Changed layout of copy summary on browse results to be in one column instead of two. Updated release notes