### PR TITLE
Hoopla Title Display

### DIFF
--- a/code/web/RecordDrivers/HooplaRecordDriver.php
+++ b/code/web/RecordDrivers/HooplaRecordDriver.php
@@ -95,9 +95,11 @@ class HooplaRecordDriver extends GroupedWorkSubDriver {
 	 */
 	public function getTitle()
 	{
-        //if episode data, display the titleTitle, so we match what is displayed in search results
+        //if episode or subtitle data, match what is displayed in search results
         if (!empty($this->hooplaRawMetadata->episode)) {
             return $this->hooplaRawMetadata->titleTitle.': '.$this->hooplaExtract->title;
+        }else if (!empty($this->hooplaRawMetadata->subtitle)) {
+            return $this->hooplaExtract->title.': '.$this->hooplaRawMetadata->subtitle;
         }else
 		return $this->hooplaExtract->title;
 	}

--- a/code/web/RecordDrivers/HooplaRecordDriver.php
+++ b/code/web/RecordDrivers/HooplaRecordDriver.php
@@ -95,6 +95,10 @@ class HooplaRecordDriver extends GroupedWorkSubDriver {
 	 */
 	public function getTitle()
 	{
+        //if episode data, display the titleTitle, so we match what is displayed in search results
+        if (!empty($this->hooplaRawMetadata->episode)) {
+            return $this->hooplaRawMetadata->titleTitle.': '.$this->hooplaExtract->title;
+        }else
 		return $this->hooplaExtract->title;
 	}
 

--- a/code/web/release_notes/22.11.00.MD
+++ b/code/web/release_notes/22.11.00.MD
@@ -59,6 +59,7 @@
 - Additional logging when there are errors updating the memory cache.
 - Minimize information returned by apache headers (do not show OS and additional information)
 - Do not return PHP information as part of headers.
+- Hoopla records with season/episode information will now display the same title on full record view as they do in search results
 
 ###This release includes code contributions from:
 - ByWater Solutions

--- a/code/web/release_notes/22.11.00.MD
+++ b/code/web/release_notes/22.11.00.MD
@@ -59,7 +59,7 @@
 - Additional logging when there are errors updating the memory cache.
 - Minimize information returned by apache headers (do not show OS and additional information)
 - Do not return PHP information as part of headers.
-- Hoopla records with season/episode information will now display the same title on full record view as they do in search results
+- Hoopla records with season/episode or subtitle information will now display the same title on full record view as they do in search results
 
 ###This release includes code contributions from:
 - ByWater Solutions

--- a/code/web/sys/Grouping/GroupedWorkDisplaySetting.php
+++ b/code/web/sys/Grouping/GroupedWorkDisplaySetting.php
@@ -161,7 +161,7 @@ class GroupedWorkDisplaySetting extends DataObject
 
 			// Catalog Enrichment //
 			'enrichmentSection' => ['property' => 'enrichmentSection', 'type' => 'section', 'label' => 'Catalog Enrichment', 'renderAsHeading' => true, 'hideInLists' => true, 'properties' => [
-				'showStandardReviews' => array('property' => 'showStandardReviews', 'type' => 'checkbox', 'label' => 'Show Standard Reviews', 'description' => 'Whether or not reviews from Content Cafe/Syndetics are displayed on the full record page.', 'hideInLists' => true, 'default' => 1),
+				'showStandardReviews' => array('property' => 'showStandardReviews', 'type' => 'checkbox', 'label' => 'Show Syndicated Reviews', 'description' => 'Whether or not reviews from Content Cafe/Syndetics are displayed on the full record page.', 'hideInLists' => true, 'default' => 1),
 				'showGoodReadsReviews' => array('property' => 'showGoodReadsReviews', 'type' => 'checkbox', 'label' => 'Show GoodReads Reviews', 'description' => 'Whether or not reviews from GoodReads are displayed on the full record page.', 'hideInLists' => true, 'default' => true),
 				'preferSyndeticsSummary' => array('property' => 'preferSyndeticsSummary', 'type' => 'checkbox', 'label' => 'Prefer Syndetics/Content Cafe Description', 'description' => 'Whether or not the Description loaded from an enrichment service should be preferred over the Description in the Marc Record.', 'hideInLists' => true, 'default' => 1),
 				'showSimilarAuthors' => array('property' => 'showSimilarAuthors', 'type' => 'checkbox', 'label' => 'Show Similar Authors', 'description' => 'Whether or not Similar Authors from Novelist is shown.', 'default' => 1, 'hideInLists' => true,),


### PR DESCRIPTION
Hoopla titles with season/episode info will now display the same title on full record view that displays in search results. Also changed "Show Standard Reviews" to "Show Syndicated Reviews" for consistency in Admin settings. Updated release notes