### PR TITLE
Account Linking and Translations

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/linkedAccounts.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/linkedAccounts.tpl
@@ -33,7 +33,11 @@
 					{/foreach}
 				</ul>
 				{if $user->id == $profile->id}{* Only allow account adding for the actual account user is logged in with *}
-					<button class="btn btn-primary btn-xs" onclick="AspenDiscovery.Account.addAccountLink()">{translate text="Add an Account" isPublicFacing=true}</button>
+					{if $profile->disableAccountLinking==0}
+						<button class="btn btn-primary btn-xs" onclick="AspenDiscovery.Account.addAccountLink()">{translate text="Add an Account" isPublicFacing=true}</button>
+						{else}
+						<p>{translate text="You currently have account linking disabled. Enable account linking for this account to add other accounts to it." isPublicFacing=true}</p>
+					{/if}
 				{else}
 					<p>{translate text="Log into this account to add other accounts to it." isPublicFacing=true}</p>
 				{/if}
@@ -41,11 +45,18 @@
 				<p>{translate text="The following accounts can view checkout and hold information from this account.  If someone is viewing your account that you do not want to have access, please contact library staff." isPublicFacing=true}</p>
 				<ul>
 				{foreach from=$profile->getViewers() item=tmpUser}
-					<li>{$tmpUser->getNameAndLibraryLabel()}</li>
+					<li>{$tmpUser->getNameAndLibraryLabel()} <button class="btn btn-xs btn-warning" onclick="AspenDiscovery.Account.removeManagingAccount({$tmpUser->id});">Remove</button> </li>
 				{foreachelse}
 					<li>{translate text="None" isPublicFacing=true}</li>
 				{/foreach}
 				</ul>
+				{if $user->id == $profile->id}{* Only allow disabling account linking for the actual account user is logged in with *}
+					{if $profile->disableAccountLinking==0}
+						<button class="btn btn-sm btn-danger" onclick="AspenDiscovery.Account.disableAccountLinkingPopup()">{translate text="Disable Account Linking" isPublicFacing=true}</button>
+					{else}
+						<button class="btn btn-sm btn-primary" onclick="AspenDiscovery.Account.disableAccountLinkingPopup()">{translate text="Enable Account Linking" isPublicFacing=true}</button>
+					{/if}
+				{/if}
 			{/if}
 		{else}
 			<div class="page">

--- a/code/web/interface/themes/responsive/Search/Recommend/multiSelectFacet.tpl
+++ b/code/web/interface/themes/responsive/Search/Recommend/multiSelectFacet.tpl
@@ -8,7 +8,7 @@
 		</div>
 	{/foreach}
 	{* Show more facet popup list *}
-	<div class="facetValue" id="more{$title}"><a href="#" onclick="AspenDiscovery.ResultsList.multiSelectMoreFacetPopup('More {$cluster.displayNamePlural}', '{$title}'); return false;">{translate text='more' isPublicFacing=true} ...</a></div>
+	<div class="facetValue" id="more{$title}"><a href="#" onclick="AspenDiscovery.ResultsList.multiSelectMoreFacetPopup('{translate text='More %1%' isPublicFacing=true 1=$cluster.displayNamePlural translateParameters=true}', '{$title}', '{translate text='Apply Filters' isPublicFacing=true}'); return false;">{translate text='more' isPublicFacing=true} ...</a></div>
 	<div id="moreFacetPopup_{$title}" style="display:none">
 		<p>{translate text="Please select one of the items below to narrow your search by %1%." 1=$cluster.label isPublicFacing=true}</p>
 		<form id="facetPopup_{$title|escapeCSS}" onsubmit="return AspenDiscovery.ResultsList.processMultiSelectMoreFacetForm('#facetPopup_{$title|escapeCSS}', '{$cluster.field_name}');">

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -5851,6 +5851,39 @@ AspenDiscovery.Account = (function () {
 			return false;
 		},
 
+		removeManagingAccount: function (idToRemove) {
+			if (confirm("Are you sure you want to break the link with this account?")) {
+				var url = Globals.path + "/MyAccount/AJAX?method=removeManagingAccount&idToRemove=" + idToRemove;
+				$.getJSON(url, function (data) {
+					if (data.result === true) {
+						AspenDiscovery.showMessage('Linked Account Removed', data.message, true, true);
+					} else {
+						AspenDiscovery.showMessage('Unable to Remove Account Link', data.message);
+					}
+				});
+			}
+			return false;
+		},
+
+		//CALL FOR ON CLICK, INITIAL MODAL POPUP
+		disableAccountLinkingPopup: function () {
+			var url = Globals.path + "/MyAccount/AJAX?method=disableAccountLinkingInfo";
+			AspenDiscovery.loadingMessage();
+				$.getJSON(url, function(data){
+					AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons);
+				}).fail(AspenDiscovery.ajaxFail);
+				return false;
+		},
+
+		//CALL FOR HITTING ACCEPT ON POPUP - GOES TO TOGGLEACCOUNTLINKING AJAX
+		toggleAccountLinkingAccept: function() {
+			var url = Globals.path + "/MyAccount/AJAX?method=toggleAccountLinking";
+			$.getJSON(url, function (data) {
+					AspenDiscovery.showMessage(data.title, data.message);
+			});
+			return false;
+		},
+
 		renewTitle: function (patronId, recordId, renewIndicator) {
 			if (Globals.loggedIn) {
 				AspenDiscovery.loadingMessage();
@@ -12680,8 +12713,8 @@ AspenDiscovery.ResultsList = (function(){
 			AspenDiscovery.showMessage(title, $("#moreFacetPopup_" + name).html());
 		},
 
-		multiSelectMoreFacetPopup: function(title, name){
-			var button = "<a class='btn btn-primary' onclick='$(\"#facetPopup_" + name + "\").submit();'>Apply Filters</a>";
+		multiSelectMoreFacetPopup: function(title, name, buttonName){
+			var button = "<a class='btn btn-primary' onclick='$(\"#facetPopup_" + name + "\").submit();'>"+buttonName+"</a>";
 			AspenDiscovery.showMessageWithButtons(title, $("#moreFacetPopup_" + name).html(), button);
 		},
 

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -5879,7 +5879,7 @@ AspenDiscovery.Account = (function () {
 		toggleAccountLinkingAccept: function() {
 			var url = Globals.path + "/MyAccount/AJAX?method=toggleAccountLinking";
 			$.getJSON(url, function (data) {
-					AspenDiscovery.showMessage(data.title, data.message);
+					AspenDiscovery.showMessage(data.title, data.message, data.success, data.success);
 			});
 			return false;
 		},

--- a/code/web/interface/themes/responsive/js/aspen/account.js
+++ b/code/web/interface/themes/responsive/js/aspen/account.js
@@ -625,7 +625,7 @@ AspenDiscovery.Account = (function () {
 		toggleAccountLinkingAccept: function() {
 			var url = Globals.path + "/MyAccount/AJAX?method=toggleAccountLinking";
 			$.getJSON(url, function (data) {
-					AspenDiscovery.showMessage(data.title, data.message);
+					AspenDiscovery.showMessage(data.title, data.message, data.success, data.success);
 			});
 			return false;
 		},

--- a/code/web/interface/themes/responsive/js/aspen/account.js
+++ b/code/web/interface/themes/responsive/js/aspen/account.js
@@ -597,6 +597,39 @@ AspenDiscovery.Account = (function () {
 			return false;
 		},
 
+		removeManagingAccount: function (idToRemove) {
+			if (confirm("Are you sure you want to break the link with this account?")) {
+				var url = Globals.path + "/MyAccount/AJAX?method=removeManagingAccount&idToRemove=" + idToRemove;
+				$.getJSON(url, function (data) {
+					if (data.result === true) {
+						AspenDiscovery.showMessage('Linked Account Removed', data.message, true, true);
+					} else {
+						AspenDiscovery.showMessage('Unable to Remove Account Link', data.message);
+					}
+				});
+			}
+			return false;
+		},
+
+		//CALL FOR ON CLICK, INITIAL MODAL POPUP
+		disableAccountLinkingPopup: function () {
+			var url = Globals.path + "/MyAccount/AJAX?method=disableAccountLinkingInfo";
+			AspenDiscovery.loadingMessage();
+				$.getJSON(url, function(data){
+					AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons);
+				}).fail(AspenDiscovery.ajaxFail);
+				return false;
+		},
+
+		//CALL FOR HITTING ACCEPT ON POPUP - GOES TO TOGGLEACCOUNTLINKING AJAX
+		toggleAccountLinkingAccept: function() {
+			var url = Globals.path + "/MyAccount/AJAX?method=toggleAccountLinking";
+			$.getJSON(url, function (data) {
+					AspenDiscovery.showMessage(data.title, data.message);
+			});
+			return false;
+		},
+
 		renewTitle: function (patronId, recordId, renewIndicator) {
 			if (Globals.loggedIn) {
 				AspenDiscovery.loadingMessage();

--- a/code/web/interface/themes/responsive/js/aspen/results-list.js
+++ b/code/web/interface/themes/responsive/js/aspen/results-list.js
@@ -17,8 +17,8 @@ AspenDiscovery.ResultsList = (function(){
 			AspenDiscovery.showMessage(title, $("#moreFacetPopup_" + name).html());
 		},
 
-		multiSelectMoreFacetPopup: function(title, name){
-			var button = "<a class='btn btn-primary' onclick='$(\"#facetPopup_" + name + "\").submit();'>Apply Filters</a>";
+		multiSelectMoreFacetPopup: function(title, name, buttonName){
+			var button = "<a class='btn btn-primary' onclick='$(\"#facetPopup_" + name + "\").submit();'>"+buttonName+"</a>";
 			AspenDiscovery.showMessageWithButtons(title, $("#moreFacetPopup_" + name).html(), button);
 		},
 

--- a/code/web/release_notes/22.12.00.MD
+++ b/code/web/release_notes/22.12.00.MD
@@ -17,6 +17,9 @@
 //Kirstien
 
 //Kodi
+-Allow patrons to block all linking to their account
+-Allow patrons to unlink accounts that manage them
+-Make "More Formats/Authors/etc" and "Apply Filters" translatable for multiselect popups (Ticket 105064)
 
 //Other
 

--- a/code/web/sys/DBMaintenance/version_updates/22.12.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/22.12.00.php
@@ -52,6 +52,13 @@ function getUpdates22_12_00(): array {
 		], //add_oauth_private_keys
 
 		//kodi
+        'user_disableAccountLinking' => [
+            'title' => 'User Disable Account Linking',
+            'description' => 'Adds switch for the user to disable account linking',
+            'sql' => [
+                "ALTER TABLE user ADD COLUMN disableAccountLinking TINYINT(1) DEFAULT '0'",
+            ]
+        ],//user_disableAccountLinking
 
 		//other
 	];


### PR DESCRIPTION
- Added user ability to block all account linking which severs currently linked accounts. 
- Added new column to user for disableAccountLinking. 
- Added check for linking accounts that prevents users from linking to accounts with account linking disabled. 
- Currently account linking information is still visible when disabled since I thought that'd be useful for testing for now. I did add a check to hide the "add account" button if account linking is disabled. 
- Added ability for users to remove specific accounts that are linking to them. 
- Added ability to translate "More Formats/Authors/etc" and "Apply Filters" for multiselect popup. 
- Updated release notes