### PR TITLE
Various Things

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/linkedAccounts.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/linkedAccounts.tpl
@@ -17,45 +17,39 @@
 			{if $offline}
 				<div class="alert alert-warning"><strong>{translate text=$offlineMessage isPublicFacing=true}</strong></div>
 			{else}
-{* MDN 7/26/2019 Do not allow access to linked accounts for linked users *}
-{*                {include file="MyAccount/switch-linked-user-form.tpl" label="View Account Settings for" actionPath="/MyAccount/LinkedAccounts"}*}
-
-				<p class="alert alert-info">
-					{translate text="Linked accounts allow you to easily maintain multiple accounts for the library so you can see all of your information in one place. Information from linked accounts will appear when you view your checkouts, holds, etc in the main account." isPublicFacing=true}
-				</p>
-				<h2>{translate text="Additional accounts to manage" isPublicFacing=true}</h2>
-				<p>{translate text="The following accounts can be managed from this account." isPublicFacing=true}</p>
-				<ul>
-					{foreach from=$profile->linkedUsers item=tmpUser}  {* Show linking for the account currently chosen for display in account settings *}
-						<li>{$tmpUser->getNameAndLibraryLabel()} <button class="btn btn-xs btn-warning" onclick="AspenDiscovery.Account.removeLinkedUser({$tmpUser->id});">Remove</button> </li>
-						{foreachelse}
-						<li>None</li>
-					{/foreach}
-				</ul>
-				{if $user->id == $profile->id}{* Only allow account adding for the actual account user is logged in with *}
-					{if $profile->disableAccountLinking==0}
+				{* MDN 7/26/2019 Do not allow access to linked accounts for linked users *}
+				{*                {include file="MyAccount/switch-linked-user-form.tpl" label="View Account Settings for" actionPath="/MyAccount/LinkedAccounts"}*}
+				{if $profile->disableAccountLinking==0}
+					<p class="alert alert-info">
+						{translate text="Linked accounts allow you to easily maintain multiple accounts for the library so you can see all of your information in one place. Information from linked accounts will appear when you view your checkouts, holds, etc in the main account." isPublicFacing=true}
+					</p>
+					<h2>{translate text="Additional accounts to manage" isPublicFacing=true}</h2>
+					<p>{translate text="The following accounts can be managed from this account." isPublicFacing=true}</p>
+					<ul>
+						{foreach from=$profile->linkedUsers item=tmpUser}  {* Show linking for the account currently chosen for display in account settings *}
+							<li>{$tmpUser->getNameAndLibraryLabel()} <button class="btn btn-xs btn-warning" onclick="AspenDiscovery.Account.removeLinkedUser({$tmpUser->id});">Remove</button> </li>
+							{foreachelse}
+							<li>None</li>
+						{/foreach}
+					</ul>
+					{if $user->id == $profile->id}{* Only allow account adding for the actual account user is logged in with *}
 						<button class="btn btn-primary btn-xs" onclick="AspenDiscovery.Account.addAccountLink()">{translate text="Add an Account" isPublicFacing=true}</button>
-						{else}
-						<p>{translate text="You currently have account linking disabled. Enable account linking for this account to add other accounts to it." isPublicFacing=true}</p>
-					{/if}
-				{else}
-					<p>{translate text="Log into this account to add other accounts to it." isPublicFacing=true}</p>
-				{/if}
-				<h2>{translate text="Other accounts that can view this account" isPublicFacing=true}</h2>
-				<p>{translate text="The following accounts can view checkout and hold information from this account.  If someone is viewing your account that you do not want to have access, please contact library staff." isPublicFacing=true}</p>
-				<ul>
-				{foreach from=$profile->getViewers() item=tmpUser}
-					<li>{$tmpUser->getNameAndLibraryLabel()} <button class="btn btn-xs btn-warning" onclick="AspenDiscovery.Account.removeManagingAccount({$tmpUser->id});">Remove</button> </li>
-				{foreachelse}
-					<li>{translate text="None" isPublicFacing=true}</li>
-				{/foreach}
-				</ul>
-				{if $user->id == $profile->id}{* Only allow disabling account linking for the actual account user is logged in with *}
-					{if $profile->disableAccountLinking==0}
-						<button class="btn btn-sm btn-danger" onclick="AspenDiscovery.Account.disableAccountLinkingPopup()">{translate text="Disable Account Linking" isPublicFacing=true}</button>
 					{else}
-						<button class="btn btn-sm btn-primary" onclick="AspenDiscovery.Account.disableAccountLinkingPopup()">{translate text="Enable Account Linking" isPublicFacing=true}</button>
+						<p>{translate text="Log into this account to add other accounts to it." isPublicFacing=true}</p>
 					{/if}
+					<h2>{translate text="Other accounts that can view this account" isPublicFacing=true}</h2>
+					<p>{translate text="The following accounts can view checkout and hold information from this account.  If someone is viewing your account that you do not want to have access, please contact library staff." isPublicFacing=true}</p>
+					<ul>
+						{foreach from=$profile->getViewers() item=tmpUser}
+							<li>{$tmpUser->getNameAndLibraryLabel()} <button class="btn btn-xs btn-warning" onclick="AspenDiscovery.Account.removeManagingAccount({$tmpUser->id});">Remove</button> </li>
+							{foreachelse}
+							<li>{translate text="None" isPublicFacing=true}</li>
+						{/foreach}
+					</ul>
+					<button class="btn btn-sm btn-danger" onclick="AspenDiscovery.Account.disableAccountLinkingPopup()">{translate text="Disable Account Linking" isPublicFacing=true}</button>
+				{else}
+					<p>{translate text="You currently have account linking disabled." isPublicFacing=true}</p>
+					<button class="btn btn-sm btn-primary" onclick="AspenDiscovery.Account.disableAccountLinkingPopup()">{translate text="Enable Account Linking" isPublicFacing=true}</button>
 				{/if}
 			{/if}
 		{else}

--- a/code/web/interface/themes/responsive/Search/advanced.tpl
+++ b/code/web/interface/themes/responsive/Search/advanced.tpl
@@ -219,9 +219,9 @@
 	{/foreach}
 	{rdelim};
 	var searchJoins = {ldelim}
-		AND: '{translate text="All Terms (AND)" inAttribute=true isPublicFacing=true}'
-		,OR: '{translate text="Any Terms (OR)" inAttribute=true isPublicFacing=true}'
-		,NOT:'{translate text="No Terms (NOT)" inAttribute=true isPublicFacing=true}'
+		AND: "{translate text="All Terms (AND)" inAttribute=true isPublicFacing=true}"
+		,OR: "{translate text="Any Terms (OR)" inAttribute=true isPublicFacing=true}"
+		,NOT:"{translate text="No Terms (NOT)" inAttribute=true isPublicFacing=true}"
 		{rdelim};
 	var addSearchString = "{translate text="Add Search Field" inAttribute=true isPublicFacing=true}";
 	var searchLabel     = "{translate text="Search for" inAttribute=true isPublicFacing=true}";

--- a/code/web/release_notes/22.12.00.MD
+++ b/code/web/release_notes/22.12.00.MD
@@ -33,6 +33,9 @@
 -Allow patrons to block all linking to their account
 -Allow patrons to unlink accounts that manage them
 -Make "More Formats/Authors/etc" and "Apply Filters" translatable for multiselect popups (Ticket 105064)
+-Allow the use of ' in translations for advance search join options (Ticket 105064)
+-Allow patrons to sort their holds by date placed for Koha (Ticket 97694)
+-Hide/show account link settings when users toggle account linking
 
 //Other
 ###Koha Updates

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -2472,7 +2472,7 @@ class MyAccount_AJAX extends JSON_Action
 				$showPosition = ($ils == 'Horizon' || $ils == 'Koha' || $ils == 'Symphony' || $ils == 'CarlX' || $ils == 'Polaris' || $ils == 'Sierra' || $ils == 'Evergreen');
 				$suspendRequiresReactivationDate = ($ils == 'Horizon' || $ils == 'CarlX' || $ils == 'Symphony' || $ils == 'Koha' || $ils == 'Polaris');
 				$interface->assign('suspendRequiresReactivationDate', $suspendRequiresReactivationDate);
-				$showPlacedColumn = ($ils == 'Symphony');
+				$showPlacedColumn = ($ils == 'Symphony' || $ils == 'Koha');
 				$interface->assign('showPlacedColumn', $showPlacedColumn);
 
 				$location = new Location();
@@ -2501,6 +2501,7 @@ class MyAccount_AJAX extends JSON_Action
 					'author' => 'Author',
 					'format' => 'Format',
 					'expire' => 'Expiration Date',
+                    'placed' => 'Date Placed',
 				);
 				if ($source == 'all' || $source == 'ils') {
 					$availableHoldSortOptions['location'] = 'Pickup Location';

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -1374,7 +1374,7 @@ class User extends DataObject
 					$indexToSortBy = $unavailableSort;
 					break;
 				case 'placed' :
-					$indexToSortBy = 'create';
+					$indexToSortBy = 'createDate';
 					break;
 				case 'libraryAccount' :
 					$indexToSortBy = 'user';


### PR DESCRIPTION
Hide/show account link settings when users toggle account linking
Allow user to sort holds by date placed for Koha and Symphony (did not find necessary data in other ils drivers) 
Allow for use of ' in translations for advanced search join phrases 
Updated release notes