### PR TITLE
BasicPage should return better HTTP response codes

### DIFF
--- a/code/web/interface/themes/responsive/Error/401.tpl
+++ b/code/web/interface/themes/responsive/Error/401.tpl
@@ -1,0 +1,16 @@
+{strip}
+	<div id="main-content" class="col-tn-12">
+		<h1>{translate text='Oops' isPublicFacing=true}</h1>
+		<div>
+			<div class="alert alert-warning">{translate text="We're sorry, but it looks like you don't have access to this page." isPublicFacing=true}</div>
+			{if !$loggedIn && $showLoginButton}
+				<div class="alert alert-info">
+					{translate text="You may be able to view this page if you sign in." isPublicFacing=true}
+				</div>
+				<div>
+					<a href='/MyAccount/Login?followupModule={$module}&followupAction={$action}&pageId={$id}' class="btn btn-primary">{translate text="Sign In" isPublicFacing=true}</a>
+				</div>
+			{/if}
+		</div>
+	</div>
+{/strip}

--- a/code/web/services/Error/Handle401.php
+++ b/code/web/services/Error/Handle401.php
@@ -1,0 +1,16 @@
+<?php
+
+require_once ROOT_DIR . '/Action.php';
+class Error_Handle401 extends Action {
+	function launch() {
+		global $interface;
+		$interface->assign('showBreadcrumbs', false);
+		http_response_code(401);
+		$this->display('401.tpl', 'Unauthorized', false);
+	}
+
+	function getBreadcrumbs() : array
+	{
+		return [];
+	}
+}


### PR DESCRIPTION
This patch makes accessing a basic page without the right permissions return a 401 instead of a plain 404 as it did before.

- response codes now match messages.
- new files added: Handle401.php and 401.tpl