### PR TITLE
Spotlighting Collections should have space now

### DIFF
--- a/code/web/interface/themes/responsive/CollectionSpotlight/formattedHorizontalCarouselTitle.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/formattedHorizontalCarouselTitle.tpl
@@ -9,7 +9,7 @@
 					<span>{$title}</span>
 				{/if}
 				{if $collectionSpotlight->showAuthor}
-					<span>{translate text=" by %1%" 1=$author isPublicFacing=true}</span>
+					<span>{translate text="&nbspby %1%" 1=$author isPublicFacing=true}</span>
 				{/if}
 			</div>
 		</a>

--- a/code/web/interface/themes/responsive/CollectionSpotlight/formattedHorizontalCarouselTitle.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/formattedHorizontalCarouselTitle.tpl
@@ -9,7 +9,7 @@
 					<span>{$title}</span>
 				{/if}
 				{if $collectionSpotlight->showAuthor}
-					<br/><span>{translate text="by %1%" 1=$author isPublicFacing=true}</span>
+					<span>{translate text=" by %1%" 1=$author isPublicFacing=true}</span>
 				{/if}
 			</div>
 		</a>

--- a/code/web/interface/themes/responsive/CollectionSpotlight/formattedHorizontalCarouselTitle.tpl
+++ b/code/web/interface/themes/responsive/CollectionSpotlight/formattedHorizontalCarouselTitle.tpl
@@ -9,7 +9,7 @@
 					<span>{$title}</span>
 				{/if}
 				{if $collectionSpotlight->showAuthor}
-					<span>{translate text="by %1%" 1=$author isPublicFacing=true}</span>
+					<br/><span>{translate text="by %1%" 1=$author isPublicFacing=true}</span>
 				{/if}
 			</div>
 		</a>

--- a/code/web/release_notes/22.12.00.MD
+++ b/code/web/release_notes/22.12.00.MD
@@ -44,6 +44,10 @@
 -Allow patrons to sort their holds by date placed for Koha (Ticket 97694)
 -Hide/show account link settings when users toggle account linking
 
+//Lucas
+###OtherUpdates
+- Fixed an issue where in a Collection Spotlight there was no space between the book's title and the connector 'by' (Ticket 92988)
+
 //Other
 ###Koha Updates
 - Update tooltip for Salutations field in self registration and contact information


### PR DESCRIPTION
This patch adds a missing space that provoked that the name of the book and the 'by' connector, corresponded to the author name, were together.

-Added a new space between book's name and 'by'