### PR TITLE
Messaging

### DIFF
--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -9783,7 +9783,7 @@ AspenDiscovery.Browse = (function(){
 				if (data.success === false) {
 					AspenDiscovery.showMessage("Unable to create category", data.message);
 				} else {
-					AspenDiscovery.showMessage("Successfully added", "This search was added to the homepage successfully.", true);
+					AspenDiscovery.showMessage("Successfully added", data.message, true);
 				}
 			}).fail(AspenDiscovery.ajaxFail);
 			return false;

--- a/code/web/interface/themes/responsive/js/aspen/browse.js
+++ b/code/web/interface/themes/responsive/js/aspen/browse.js
@@ -425,7 +425,7 @@ AspenDiscovery.Browse = (function(){
 				if (data.success === false) {
 					AspenDiscovery.showMessage("Unable to create category", data.message);
 				} else {
-					AspenDiscovery.showMessage("Successfully added", "This search was added to the homepage successfully.", true);
+					AspenDiscovery.showMessage("Successfully added", data.message, true);
 				}
 			}).fail(AspenDiscovery.ajaxFail);
 			return false;

--- a/code/web/release_notes/22.12.00.MD
+++ b/code/web/release_notes/22.12.00.MD
@@ -64,6 +64,8 @@
 -Prompt user to update PIN/Password after removing managing accounts if library allows for PIN reset
 -Removed old functionality for disabling account linking upon pin reset
 -Updated messaging for when accounts are linked to
+-Updated messaging for when linkees remove managing accounts or disable account linking
+-Fixed messaging issue when not adding browse category to home page (Ticket 9997)
 
 //Lucas
 ###OtherUpdates


### PR DESCRIPTION
Updated messaging for when account linkees break a link to the linker - either by disabling linking or by individually breaking a link 
Fixed messaging for when browse categories aren't being added to the homepage 
Updated release notes