### PR TITLE
Small Linking Fixes

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/addAccountLink.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/addAccountLink.tpl
@@ -1,6 +1,6 @@
 {strip}
 	<p class="alert alert-danger" id="loginError" style="display: none"></p>
-	<form method="post" action="{if !empty($loginReferer)}{$loginReferer}{else}/MyAccount/Home{/if}" id="loginForm" class="form-horizontal" role="form" onsubmit="return AspenDiscovery.Account.processAjaxLogin()">
+	<form id="loginForm" class="form-horizontal" role="form" onsubmit="AspenDiscovery.Account.processAddLinkedUser()">
 		<div id="missingLoginPrompt" style="display: none">{translate text="Please enter both %1% and %2%." 1=$usernameLabel 2=$passwordLabel translateParameters=true isPublicFacing=true}</div>
 		<div id='loginUsernameRow' class='form-group'>
 			<label for="username" class='control-label col-xs-12 col-sm-4'>{translate text=$usernameLabel isPublicFacing=true}</label>

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -5892,8 +5892,9 @@ AspenDiscovery.Account = (function () {
 		//CALL FOR HITTING ACCEPT ON POPUP - GOES TO TOGGLEACCOUNTLINKING AJAX
 		toggleAccountLinkingAccept: function() {
 			var url = Globals.path + "/MyAccount/AJAX?method=toggleAccountLinking";
+			AspenDiscovery.loadingMessage();
 			$.getJSON(url, function (data) {
-				AspenDiscovery.showMessage(data.title, data.message, data.success, data.success);
+				AspenDiscovery.showMessageWithButtons(data.title, data.message, data.modalButtons, data.success);
 			});
 			return false;
 		},
@@ -5914,7 +5915,7 @@ AspenDiscovery.Account = (function () {
 		},
 
 		redirectPinReset: function() {
-			window.location.href = Globals.path + "/MyAccount/RequestPinReset";
+			window.location.href = Globals.path + "/MyAccount/ResetPinPage";
 		},
 
 		renewTitle: function (patronId, recordId, renewIndicator) {

--- a/code/web/interface/themes/responsive/js/aspen/account.js
+++ b/code/web/interface/themes/responsive/js/aspen/account.js
@@ -630,8 +630,9 @@ AspenDiscovery.Account = (function () {
 		//CALL FOR HITTING ACCEPT ON POPUP - GOES TO TOGGLEACCOUNTLINKING AJAX
 		toggleAccountLinkingAccept: function() {
 			var url = Globals.path + "/MyAccount/AJAX?method=toggleAccountLinking";
+			AspenDiscovery.loadingMessage();
 			$.getJSON(url, function (data) {
-				AspenDiscovery.showMessage(data.title, data.message, data.success, data.success);
+				AspenDiscovery.showMessageWithButtons(data.title, data.message, data.modalButtons, data.success);
 			});
 			return false;
 		},
@@ -652,7 +653,7 @@ AspenDiscovery.Account = (function () {
 		},
 
 		redirectPinReset: function() {
-			window.location.href = Globals.path + "/MyAccount/RequestPinReset";
+			window.location.href = Globals.path + "/MyAccount/ResetPinPage";
 		},
 
 		renewTitle: function (patronId, recordId, renewIndicator) {

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -351,17 +351,39 @@ class MyAccount_AJAX extends JSON_Action {
 			} else {
 				if ($user->disableAccountLinking == 0) {
 					$success = $user->accountLinkingToggle();
-					$result = [
-						'success' => $success,
-						'title' => translate([
-							'text' => 'Linking Disabled',
-							'isPublicFacing' => true,
-						]),
-						'message' => translate([
-							'text' => 'Account linking has been disabled',
-							'isPublicFacing' => true,
-						]),
-					];
+					global $librarySingleton;
+					// Get Library Settings from the home library of the current user-account being displayed
+					$patronHomeLibrary = $librarySingleton->getPatronHomeLibrary($user);
+					if ($patronHomeLibrary->allowPinReset == 1) {
+						$result = [
+							'success' => $success,
+							'title' => translate([
+								'text' => 'Linking Disabled',
+								'isPublicFacing' => true,
+							]),
+							'message' => translate([
+								'text' => 'Account linking has been disabled. Disabling account linking does not guarantee the security of your account. If another user has your barcode and PIN/password they will still be able to access your account. Would you like to change your password?',
+								'isPublicFacing' => true,
+							]),
+							'modalButtons' => "<span class='tool btn btn-primary' onclick='AspenDiscovery.Account.redirectPinReset(); return false;'>" . translate([
+									'text' => "Request PIN Change",
+									'isPublicFacing' => true,
+								]) . "</span>",
+						];
+					} else {
+						$result = [
+							'success' => $success,
+							'title' => translate([
+								'text' => 'Linking Disabled',
+								'isAdminFacing' => 'true',
+							]),
+							'message' => translate([
+								'text' => 'Account linking has been disabled. Disabling account linking does not guarantee the security of your account. If another user has your barcode and PIN/password they will still be able to access your account. Please contact your library if you wish to update your PIN/Password.',
+								'isPublicFacing' => true,
+							]),
+						];
+
+					}
 				} else {
 					$result = [
 						'success' => false,

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -708,7 +708,7 @@ class User extends DataObject {
 		$userMessage->messageType = 'linked_acct_notify_removed_' . $this->id;
 		$userMessage->userId = $userId;
 		$userMessage->isDismissed = "0";
-		$userMessage->message = "An account you were previously linked to, $this->displayName, has removed the link to your account. To learn more about linked accounts, please visit /MyAccount/LinkedAccounts";
+		$userMessage->message = "An account you were previously linked to, $this->displayName, has removed the link to your account. To learn more about linked accounts, please visit your <a href='/MyAccount/LinkedAccounts'>Linked Accounts</a> page";
 		$userMessage->update();
 
 		//Force a reload of data


### PR DESCRIPTION
- Go to /MyAccount/ResetPinPage instead of /MyAccount/RequestPinReset 
- Submit processAddLinkedUser() when hitting enter on the username/password input modal for adding a link
- Add prompt to change pin for users disabling account linking (if library does not allow, tell user to contact library) 
- If user removes managing account, notify that managing account and link to /MyAccount/LinkedAccounts