### PR TITLE
Account Linking Changes

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/addAccountLink.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/addAccountLink.tpl
@@ -11,7 +11,7 @@
 		<div id='loginPasswordRow' class='form-group'>
 			<label for="password" class='control-label col-xs-12 col-sm-4'>{translate text=$passwordLabel isPublicFacing=true} </label>
 			<div class='col-xs-12 col-sm-8'>
-				<input type="password" name="password" id="password" size="28" maxlength="60" onkeypress="return AspenDiscovery.submitOnEnter(event, '#loginForm');" class="form-control"/>
+				<input type="password" name="password" id="password" size="28" maxlength="60" class="form-control"/>
 			</div>
 		</div>
 		<div id='loginPasswordRow2' class='form-group'>
@@ -24,3 +24,17 @@
 		</div>
 	</form>
 {/strip}
+{literal}
+	<script type="text/javascript">
+		$(function () {
+			addEventListener("keypress", function(event) {
+				// If the user presses the "Enter" key on the keyboard
+				if (event.key === "Enter") {
+					event.preventDefault();
+					// Trigger the button element with a click
+					document.getElementById("AddAccountSubmit").click();
+				}
+			});
+		})
+	</script>
+{/literal}

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -413,7 +413,7 @@ class MyAccount_AJAX extends JSON_Action {
 				'isPublicFacing' => true,
 			]),
 			'modalBody' => $interface->fetch('MyAccount/addAccountLink.tpl'),
-			'modalButtons' => "<span class='tool btn btn-primary' onclick='AspenDiscovery.Account.processAddLinkedUser(); return false;'>" . translate([
+			'modalButtons' => "<span class='tool btn btn-primary' id = 'AddAccountSubmit' onclick='AspenDiscovery.Account.processAddLinkedUser(); return false;'>" . translate([
 					'text' => "Add Account",
 					'isPublicFacing' => true,
 				]) . "</span>",

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -2428,7 +2428,7 @@ class User extends DataObject {
 				]);
 				$userMessage->action1 = "return AspenDiscovery.Account.allowAccountLink()";
 				$userMessage->action2Title = translate([
-					'text' => "No",
+					'text' => "Manage Linked Accounts",
 					'isPublicFacing' => true,
 				]);
 				$userMessage->action2 = "return AspenDiscovery.Account.redirectLinkedAccounts()";


### PR DESCRIPTION
When hitting 'enter' in the Add Account Link modal - the modal would close and the page would refresh and if there were an error, the message wouldn't show. Added an event listener for the user hitting enter that will just click the submit button so messaging shows as intended. 
Changed "No" to "Manage Linked Accounts" in user message asking if user wants to continue allowing a new link