### PR TITLE
Dismiss Message for Linked Account

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/expirationFinesNotice.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/expirationFinesNotice.tpl
@@ -7,9 +7,9 @@
 					<div class="myAccountLink">
 						<a href="{$eCommerceLink}" {if $finePaymentType == 1}target="_blank"{/if}{if $showRefreshAccountButton} onclick="AspenDiscovery.Account.ajaxLightbox('/AJAX/JSON?method=getPayFinesAfterAction')"{/if}  style="color:#c62828; font-weight:bold;">
 							{if count($user->getLinkedUsers())>0}
-								{translate text="Your accounts have %1% in fines." 1=$ilsSummary->totalFines|formatCurrency isPublicFacing=true}
+								{translate text="Your accounts have %1% in fines." 1=$ilsSummary->totalFines|formatCurrency inAttribute=true isPublicFacing=true}
 							{else}
-								{translate text="Your account has %1% in fines." 1=$ilsSummary->totalFines|formatCurrency isPublicFacing=true}
+								{translate text="Your account has %1% in fines." 1=$ilsSummary->totalFines|formatCurrency inAttribute=true isPublicFacing=true}
 							{/if}
 						</a>
 					</div>

--- a/code/web/interface/themes/responsive/MyAccount/fines.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/fines.tpl
@@ -22,7 +22,7 @@
 			{* Show Fine Alert when the user has no linked accounts *}
 			{if count($userFines) == 1 && $profile->_fines}
 				<div class="alert alert-info">
-					{translate text="Your account has <strong>%1%</strong> in fines." 1=$profile->_fines isPublicFacing=true}
+					{translate text="Your account has <strong>%1%</strong> in fines." 1=$profile->_fines inAttribute=true isPublicFacing=true}
 				</div>
 			{/if}
 

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -5912,6 +5912,12 @@ AspenDiscovery.Account = (function () {
 
 		redirectLinkedAccounts: function() {
 			window.location.href = Globals.path + "/MyAccount/LinkedAccounts";
+			var url = Globals.path + "/MyAccount/AJAX";
+			var params = {
+				method: "allowAccountLink" //dismisses "confirm_linked_accts" message but we won't display "link accepted" message
+			};
+			$.getJSON(url, params).fail(AspenDiscovery.ajaxFail);
+			return false;
 		},
 
 		redirectPinReset: function() {

--- a/code/web/interface/themes/responsive/js/aspen/account.js
+++ b/code/web/interface/themes/responsive/js/aspen/account.js
@@ -650,6 +650,12 @@ AspenDiscovery.Account = (function () {
 
 		redirectLinkedAccounts: function() {
 			window.location.href = Globals.path + "/MyAccount/LinkedAccounts";
+			var url = Globals.path + "/MyAccount/AJAX";
+			var params = {
+				method: "allowAccountLink" //dismisses "confirm_linked_accts" message but we won't display "link accepted" message
+			};
+			$.getJSON(url, params).fail(AspenDiscovery.ajaxFail);
+			return false;
 		},
 
 		redirectPinReset: function() {


### PR DESCRIPTION
When clicking "manage linked accounts" button in message for a new link, bring patron to /MyAccount/LinkedAccounts and dismiss message