### PR TITLE
Sierra Name Display

### DIFF
--- a/code/web/Drivers/Sierra.php
+++ b/code/web/Drivers/Sierra.php
@@ -1065,8 +1065,8 @@ class Sierra extends Millennium {
 		$primaryName = reset($patronInfo->names);
 		if (strpos($primaryName, ',') !== false) {
 			[
-				$firstName,
 				$lastName,
+				$firstName,
 			] = explode(',', $primaryName, 2);
 		} else {
 			$lastName = $primaryName;


### PR DESCRIPTION
Fix names displaying wrong in Sierra, names are stored as 'lastname, firstname'