### PR TITLE
Grouped Work Display

### DIFF
--- a/code/web/release_notes/23.01.00.MD
+++ b/code/web/release_notes/23.01.00.MD
@@ -18,6 +18,7 @@
 -When adding a browse category, categories listed in the "Add as a Sub-Category to" dropdown will include the category's id number to the right of the name (Ticket 99997)
 -When enabling search tools, "Show at Top of Page" option will show, if search tools are disabled this option will not display
 -Fixed an issue where patron names were displaying incorrectly for Sierra libraries (Ticket 106295)
+-For those with Novelist: when updating grouped work display info for series/volume, use the updated info instead of Novelist data (Tickets 93967, 100475, 104760, 106835)
 
 // other
 - Update nightly database dump to handle additional server configurations.


### PR DESCRIPTION
If a library has Novelist but updates grouped work display for series or volume, use that updated information instead of Novelist data
Updated release notes