### PR TITLE
Index Sitemaps

### DIFF
--- a/code/web/release_notes/23.01.00.MD
+++ b/code/web/release_notes/23.01.00.MD
@@ -38,6 +38,7 @@
 -For those with Novelist: when updating grouped work display info for series/volume, use the updated info instead of Novelist data (Tickets 93967, 100475, 104760, 106835)
 -Added ability to assign account linking settings by patron type, individual and bulk updates of this setting will relay messaging to admin notifying them of what these changes will do
 -Fixed an issue placing holds on multi-edition items that are checked out or in transit (Ticket 107860)
+-Added functionality to index sitemaps
 
 // other
 - Update nightly database dump to handle additional server configurations.


### PR DESCRIPTION
Adds functionality to index sitemaps. 
- If sitemap is a sitemap index (ex: https://www.gymshark.com/sitemap.xml), it will index each individual sitemap in that sitemap index.
- In "paths to exclude", to exclude a site from the sitemap, put the full path in (ex: https://www.gymshark.com/about-us) and the indexer will skip that path.

Updated release notes.