### PR TITLE
Materials Request Usage Dashboard

### DIFF
--- a/code/web/interface/themes/responsive/MaterialsRequest/dashboard.tpl
+++ b/code/web/interface/themes/responsive/MaterialsRequest/dashboard.tpl
@@ -1,18 +1,6 @@
 {strip}
 	<div id="main-content" class="col-sm-12">
 		<h1>{translate text="Materials Request Dashboard" isAdminFacing=true}</h1>
-		{if count($locationsToRestrictTo) > 1}
-        	<form name="selectInterface" id="selectInterface" class="form-inline row">
-        		<div class="form-group col-tn-6">
-        			<label for="location" class="control-label">{translate text="Location to show stats for" isAdminFacing=true}</label>&nbsp;
-        			<select id="location" name="location" class="form-control input-sm" onchange="$('#selectInterface').submit()">
-        				{foreach from=$locationsToRestrictTo key=id item=curLocation}
-        					<option value="{$id}" {if $id == $selectedLocation}selected{/if}>{$curLocation.displayLabel}</option>
-        				{/foreach}
-        			</select>
-        		</div>
-        	</form>
-        {/if}
 
 <div class="row">
 		{foreach from=$allStats key=label item=statusStats}

--- a/code/web/services/MaterialsRequest/Dashboard.php
+++ b/code/web/services/MaterialsRequest/Dashboard.php
@@ -13,50 +13,24 @@ class MaterialsRequest_Dashboard extends Admin_Dashboard {
 			global $library;
 			$userHomeLibrary = $library;
 		}
-		$locations = new Location();
-		$locations->libraryId = $userHomeLibrary->libraryId;
-		$locations->find();
-		$locationsForLibrary = [];
-		$locationsForLibrary['']['displayLabel'] = translate([
-			'text' => 'All',
-			'isAdminFacing' => true,
-			'inAttribute' => true,
-		]);
-		while ($locations->fetch()) {
-			$locationsForLibrary[$locations->locationId]['id'] = $locations->locationId;
-			$locationsForLibrary[$locations->locationId]['displayLabel'] = $locations->displayName;
-		}
-
-		if (!empty($_REQUEST['location'])) {
-			$locationId = $_REQUEST['location'];
-		} else {
-			$locationId = '';
-		}
-		$interface->assign('selectedLocation', $locationId);
-		$interface->assign('locationsToRestrictTo', $locationsForLibrary);
+		$libraryId = $userHomeLibrary->libraryId;
+		$interface->assign('selectedLocation', $libraryId);
 
 		$this->loadDates();
 
 		$allStatuses = [];
 		$statuses = new MaterialsRequestStatus();
-		$statuses->libraryId = $userHomeLibrary->libraryId;
+		$statuses->libraryId = $libraryId;
 		$statuses->find();
 		while ($statuses->fetch()) {
 			$allStatuses[$statuses->id]['id'] = $statuses->id;
 			$allStatuses[$statuses->id]['label'] = $statuses->description;
-			if ($locationId !== '') {
-				$allStatuses[$statuses->id]['usageThisMonth'] = $this->getStats($locationId, $this->thisMonth, $this->thisYear, $statuses);
-				$allStatuses[$statuses->id]['usageLastMonth'] = $this->getStats($locationId, $this->lastMonth, $this->lastMonthYear, $statuses);
-				$allStatuses[$statuses->id]['usageThisYear'] = $this->getStats($locationId, null, $this->thisYear, $statuses);
-				$allStatuses[$statuses->id]['usageLastYear'] = $this->getStats($locationId, null, $this->lastYear, $statuses);
-				$allStatuses[$statuses->id]['usageAllTime'] = $this->getStats($locationId, null, null, $statuses);
-			} else {
-				$allStatuses[$statuses->id]['usageThisMonth'] = $this->getStats($locationsForLibrary, $this->thisMonth, $this->thisYear, $statuses);
-				$allStatuses[$statuses->id]['usageLastMonth'] = $this->getStats($locationsForLibrary, $this->lastMonth, $this->lastMonthYear, $statuses);
-				$allStatuses[$statuses->id]['usageThisYear'] = $this->getStats($locationsForLibrary, null, $this->thisYear, $statuses);
-				$allStatuses[$statuses->id]['usageLastYear'] = $this->getStats($locationsForLibrary, null, $this->lastYear, $statuses);
-				$allStatuses[$statuses->id]['usageAllTime'] = $this->getStats($locationsForLibrary, null, null, $statuses);
-			}
+				$allStatuses[$statuses->id]['usageThisMonth'] = $this->getStats($libraryId, $this->thisMonth, $this->thisYear, $statuses);
+				$allStatuses[$statuses->id]['usageLastMonth'] = $this->getStats($libraryId, $this->lastMonth, $this->lastMonthYear, $statuses);
+				$allStatuses[$statuses->id]['usageThisYear'] = $this->getStats($libraryId, null, $this->thisYear, $statuses);
+				$allStatuses[$statuses->id]['usageLastYear'] = $this->getStats($libraryId, null, $this->lastYear, $statuses);
+				$allStatuses[$statuses->id]['usageAllTime'] = $this->getStats($libraryId, null, null, $statuses);
+
 		}
 
 		$interface->assign('allStats', $allStatuses);
@@ -75,7 +49,7 @@ class MaterialsRequest_Dashboard extends Admin_Dashboard {
 			foreach ($location as $loc) {
 				if ($loc['displayLabel'] != "All") {
 					$stats = new MaterialsRequestUsage();
-					$stats->locationId = $loc['id'];
+					$stats->libraryId = $loc['id'];
 					if ($month != null) {
 						$stats->month = $month;
 					}
@@ -98,7 +72,7 @@ class MaterialsRequest_Dashboard extends Admin_Dashboard {
 		} else {
 			$stats = new MaterialsRequestUsage();
 			if (!empty($location)) {
-				$stats->locationId = $location;
+				$stats->libraryId = $location;
 			}
 			if ($month != null) {
 				$stats->month = $month;
@@ -137,7 +111,6 @@ class MaterialsRequest_Dashboard extends Admin_Dashboard {
 	}
 
 	function exportToExcel() {
-		$location = $_REQUEST['location'];
 		$periods = $this->getAllPeriods();
 
 		header('Content-Type: text/csv; charset=utf-8');
@@ -147,93 +120,52 @@ class MaterialsRequest_Dashboard extends Admin_Dashboard {
 
 		$header[] = 'Date';
 
-		if ($location !== '' && $location !== null) {
+		$userHomeLibrary = Library::getPatronHomeLibrary();
+		if (is_null($userHomeLibrary)) {
+			//User does not have a home library, this is likely an admin account.  Use the active library
+			global $library;
+			$userHomeLibrary = $library;
+		}
+		$locations = new Location();
+		$locations->libraryId = $userHomeLibrary->libraryId;
+		$locations->find();
+		while ($locations->fetch()) {
 			$thisStatus = new MaterialsRequestStatus();
-			$thisStatus->libraryId = $location;
+			$thisStatus->libraryId = $locations->libraryId;
 			$thisStatus->find();
 
-			while ($thisStatus->fetch()) { //loop through each status and get description for header
+			while ($thisStatus->fetch()) {
 				$header[] = $thisStatus->description;
 			}
 			fputcsv($fp, $header);
 
-			foreach ($periods as $period) { //each row is a different time period
+			foreach ($periods as $period) {
 				$materialsRequestUsage = new MaterialsRequestUsage();
 				$materialsRequestUsage->year = $period['year'];
 				$materialsRequestUsage->month = $period['month'];
 				$materialsRequestUsage->statusId = $thisStatus->id;
-				$materialsRequestUsage->locationId = $location;
 				$materialsRequestUsage->find();
 
-				$row = []; //empty new rows
+				$row = [];
 				$date = "{$materialsRequestUsage->month}-{$materialsRequestUsage->year}";
-				$row[] = $date; //add date first
+				$row[] = $date;
 
 				$thisStatus = new MaterialsRequestStatus();
-				$thisStatus->libraryId = $location;
+				$thisStatus->libraryId = $locations->libraryId;
 				$thisStatus->find();
 
-				while ($thisStatus->fetch()){ //loop through statuses again
+				while ($thisStatus->fetch()){
 					$materialsRequestUsage = new MaterialsRequestUsage();
 					$materialsRequestUsage->year = $period['year'];
 					$materialsRequestUsage->month = $period['month'];
 					$materialsRequestUsage->statusId = $thisStatus->id;
-					if ($materialsRequestUsage->find(true)){ //if we find a match on year, month, and id/statusId
+					if ($materialsRequestUsage->find(true)){
 						$row[] = $materialsRequestUsage->numUsed ?? 0;
-					}else{ //otherwise, usage is 0
+					}else{
 						$row[] = 0;
 					}
 				}
 				fputcsv($fp, $row);
-			}
-		} else {
-			$userHomeLibrary = Library::getPatronHomeLibrary();
-			if (is_null($userHomeLibrary)) {
-				//User does not have a home library, this is likely an admin account.  Use the active library
-				global $library;
-				$userHomeLibrary = $library;
-			}
-			$locations = new Location();
-			$locations->libraryId = $userHomeLibrary->libraryId;
-			$locations->find();
-			while ($locations->fetch()) {
-				$thisStatus = new MaterialsRequestStatus();
-				$thisStatus->libraryId = $locations->locationId;
-				$thisStatus->find();
-
-				while ($thisStatus->fetch()) {
-					$header[] = $thisStatus->description;
-				}
-				fputcsv($fp, $header);
-
-				foreach ($periods as $period) {
-					$materialsRequestUsage = new MaterialsRequestUsage();
-					$materialsRequestUsage->year = $period['year'];
-					$materialsRequestUsage->month = $period['month'];
-					$materialsRequestUsage->statusId = $thisStatus->id;
-					$materialsRequestUsage->find();
-
-					$row = [];
-					$date = "{$materialsRequestUsage->month}-{$materialsRequestUsage->year}";
-					$row[] = $date;
-
-					$thisStatus = new MaterialsRequestStatus();
-					$thisStatus->libraryId = $locations->locationId;
-					$thisStatus->find();
-
-					while ($thisStatus->fetch()){
-						$materialsRequestUsage = new MaterialsRequestUsage();
-						$materialsRequestUsage->year = $period['year'];
-						$materialsRequestUsage->month = $period['month'];
-						$materialsRequestUsage->statusId = $thisStatus->id;
-						if ($materialsRequestUsage->find(true)){
-							$row[] = $materialsRequestUsage->numUsed ?? 0;
-						}else{
-							$row[] = 0;
-						}
-					}
-					fputcsv($fp, $row);
-				}
 			}
 		}
 		exit;

--- a/code/web/sys/DBMaintenance/version_updates/23.01.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.01.00.php
@@ -177,6 +177,14 @@ function getUpdates23_01_00(): array
 			]
 		],
 		//migrate_records_owned
+		'rename_materialreq_usage_locID_column' => [
+			'title' => 'Rename locationId column for Materials Request Usage',
+			'description' => 'Rename locationId column for Materials Request Usage',
+			'sql' => [
+				"ALTER TABLE materials_request_usage RENAME COLUMN locationId TO libraryId",
+			]
+		],
+		//rename_materialreq_usage_locID_column
 		//other
 	];
 }

--- a/code/web/sys/MaterialsRequestUsage.php
+++ b/code/web/sys/MaterialsRequestUsage.php
@@ -4,7 +4,7 @@
 class MaterialsRequestUsage extends DataObject {
 	public $__table = 'materials_request_usage';
 	public $id;
-	public $locationId;
+	public $libraryId;
 	public $year;
 	public $month;
 	public $statusId;
@@ -24,7 +24,7 @@ class MaterialsRequestUsage extends DataObject {
 			$materialsRequestUsage = new MaterialsRequestUsage();
 			$materialsRequestUsage->year = date('Y');
 			$materialsRequestUsage->month = date('n');
-			$materialsRequestUsage->locationId = $homeLocation;
+			$materialsRequestUsage->libraryId = $homeLocation;
 			$materialsRequestUsage->statusId = $status;
 			if ($materialsRequestUsage->find(true)) {
 				$materialsRequestUsage->numUsed++;


### PR DESCRIPTION
- Changed column name in materials_request_usage from "locationId" to "libraryId" since that's what is being stored in that column 
- Updated other files to reflect this change in nomenclature 
- Dropped ability to choose location on this dashboard since it wasn't working correctly - we will now pull the stats for the user's home library. If they are an admin with no home library, stats will show for the active library. 
- Updated usage dashboard csv exports to reflect this change