### PR TITLE
OPACSuggestionMandatoryFields 

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -3904,7 +3904,7 @@ class Koha extends AbstractIlsDriver {
 		}
 
 		if (isset($kohaPreferences['OPACSuggestionMandatoryFields'])) {
-			$mandatoryFields = array_flip(explode(',', $kohaPreferences['OPACSuggestionMandatoryFields']));
+			$mandatoryFields = array_flip(explode('|', $kohaPreferences['OPACSuggestionMandatoryFields']));
 		} else {
 			$mandatoryFields = [];
 		}


### PR DESCRIPTION
Fix for Koha ILS materials request form not honoring mandatory fields set
