### PR TITLE
PHP 8/Smarty Updates

### DIFF
--- a/code/web/interface/themes/responsive/Record/evergreenHoldNotifications.tpl
+++ b/code/web/interface/themes/responsive/Record/evergreenHoldNotifications.tpl
@@ -28,14 +28,14 @@
 				<select name="smsCarrier" id="smsCarrier" class="form-control">
 					<option value="-1">{translate text="Please select a carrier" isPublicFacing=true}</option>
 					{foreach from=$smsCarriers item=smsCarrier key=smsCarrierId}
-						<option value="{$smsCarrierId}" {if $opac_default_sms_carrier == $smsCarrierId}selected{/if}>{$smsCarrier}</option>
+						<option value="{$smsCarrierId}" {if !empty($opac_default_sms_carrier)}{if $opac_default_sms_carrier == $smsCarrierId}selected{/if}{/if}>{$smsCarrier}</option>
 					{/foreach}
 				</select>
 				<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {translate text="Note: carrier charges may apply " isAdminFacing=true}</small></span>
 			</div>
 			<div class="form-group">
 				<label class="control-label" for="smsNumber">{translate text="Mobile Number" isPublicFacing=true}</label>
-				<input type="tel" name="smsNumber" id="smsNumber" class="form-control" size="10" value="{$opac_default_sms_notify}">
+				<input type="tel" name="smsNumber" id="smsNumber" class="form-control" size="10" {if !empty($opac_default_sms_notify)}value="{$opac_default_sms_notify}"{/if}>
 				<span id="{$propName}HelpBlock" class="help-block" style="margin-top:0"><small class="text-warning"><i class="fas fa-exclamation-triangle"></i> {translate text="Hint: use the full 10 digits of your phone #, no spaces, no dashes" isAdminFacing=true}</small></span>
 			</div>
 		</div>


### PR DESCRIPTION
Fix for smarty errors on porter county place hold modal for mobile carrier and mobile number:

Warning: Attempt to read property "value" on null in /usr/local/aspen-discovery/tmp/smarty/compile/9b434256fcacb8a2becae83323f0610faadcdb1c_0.file.evergreenHoldNotifications.tpl.php on line 43

and

Warning: Attempt to read property "value" on null in /usr/local/aspen-discovery/tmp/smarty/compile/9b434256fcacb8a2becae83323f0610faadcdb1c_0.file.evergreenHoldNotifications.tpl.php on line 47