### PR TITLE
Debian installer updates

### DIFF
--- a/code/cron/nightly_mysql_dump.sh
+++ b/code/cron/nightly_mysql_dump.sh
@@ -35,11 +35,7 @@ if [[ $# -eq 0 ]]; then
 else
 ASPENSERVER=$1
 
-if [[ $# -eq 2 ]]; then
-	DBNAME=$2
-else
-	DBNAME="aspen"
-fi
+DBNAME=${2:-aspen}
 echo "Dumping $DBNAME database"
 
 #-------------------------------------------------------------------------
@@ -58,8 +54,19 @@ fi
 echo "Dumping to $DUMPFOLDER"
 
 DATABASES="$DBNAME"
-DUMPOPT1="--defaults-file=/etc/my.cnf --events"
-DUMPOPT2="--defaults-file=/etc/my.cnf --events --single-transaction"
+
+DEF=/etc/my.cnf
+if [ ! -e "$DEF" ]
+then
+  DEF=/etc/mysql/mariadb.conf.d/60-aspen.cnf
+  if [ ! -e "$DEF" ]
+  then
+    echo "Defaults file not found!"
+    exit 1
+  fi
+fi
+DUMPOPT1="--defaults-file=$DEF --events"
+DUMPOPT2="--defaults-file=$DEF --events --single-transaction"
 
 #-------------------------------------------------------------------------
 # main loop

--- a/install/60-aspen.cnf
+++ b/install/60-aspen.cnf
@@ -1,0 +1,32 @@
+[mysqld]
+#Make sure that we use utf-8 always
+init_connect = 'SET collation_connection = utf8mb4_general_ci'
+init_connect = 'SET NAMES utf8mb4'
+character-set-server = utf8mb4
+collation-server = utf8mb4_general_ci
+
+# other variables here
+innodb_buffer_pool_instances = 3
+innodb_buffer_pool_size = 3584M # (adjust value here, 50%-70% of total RAM)
+innodb_log_file_size = 448M
+innodb_flush_log_at_trx_commit = 1 # may change to 2 or 0
+innodb_flush_method = O_DIRECT
+skip-name-resolve = 1
+query_cache_size = 0
+query_cache_type = 0
+query_cache_limit = 3M
+key_buffer_size = 5M
+join_buffer_size = 1M
+table_open_cache = 300
+performance_schema = ON
+slow_query_log=1
+long_query_time=1
+max_connections = 128
+tmp_table_size=256M
+max_heap_table_size=256M
+
+[mysqldump]
+host = localhost
+port = 3306
+user = {aspenDBUser}
+password = {aspenDBPwd}

--- a/install/createSite.php
+++ b/install/createSite.php
@@ -201,7 +201,7 @@ $centos = [
 $debian = [
 	'wwwUser' => 'www-data',
 	'service' => 'apache2',
-	'mysqlConf' => '/etc/mysql/mariadb.cnf',
+	'mysqlConf' => '/etc/mysql/mariadb.conf.d/60-aspen.cnf',
 	'permissions' => 'updateSitePermissions_debian.sh',
 	'apacheDir' => '/etc/apache2/sites-available'
 ];

--- a/install/installer_debian.sh
+++ b/install/installer_debian.sh
@@ -1,73 +1,62 @@
 #!/bin/sh
 
-#This will need to be copied to the server manually to do the setup.
-#Expects to be installed on Debian 10 Buster
-#Run as sudo ./installer.sh
-apt update
-apt install -y wget
-apt install -y apache2
-apt -y install apt-transport-https lsb-release ca-certificates curl
-wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
-sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
-apt update
-apt install -y php7.3 php7.3-mcrypt php7.3-gd php7.3-curl php7.3-mysql php7.3-zip
-apt install -y php7.3-xml
-apt install -y bind9 bind9utils
-apt install -y php7.3-intl
-apt install -y php7.3-mbstring
-apt install -y php7.3-pgsql
-apt install -y php7.3-ssh2
-service apache2 start
-systemctl enable apache2
-# New PHP ini file
-# - Change max_memory to 256M (from 128M)
-# - Increase max file size to 50M
-# - Increase max post size to 50M
-mv /etc/php/7.3/apache2/php.ini /etc/php/7.3/apache2/php.ini.old
-cp php.ini /etc/php/7.3/apache2/php.ini
+#Expects to be installed on Debian 10 Buster or later
+#Run as sudo ./installer_debian.sh
+apt-get update
+apt-get -y install gpg openjdk-11-jre-headless openjdk-11-jdk-headless apache2 certbot python3-certbot-apache mariadb-server apt-transport-https lsb-release ca-certificates curl zip
+
+# Install Ondrej Sury's php repo for access to additional PHP versions
+keyrings="/etc/apt/keyrings"
+test -d "$keyrings" || (mkdir -p "$keyrings" ; chmod 0755 "$keyrings")
+if ! test -f "$keyrings/sury.gpg" || ! test -f /etc/apt/sources.list.d/sury.list ; then
+  wget -q -O - https://packages.sury.org/php/apt.gpg | gpg -o "$keyrings/sury.gpg" --dearmor
+  echo "deb [signed-by=$keyrings/sury.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/sury.list
+  apt-get update
+fi
+
+# Override default OS PHP version
+php_vers="8.0"
+
+# Have to use versions for these or the highest version available is installed.
+apt-get install -y "php${php_vers}" "php${php_vers}-mcrypt" "php${php_vers}-gd" "php${php_vers}-curl" "php${php_vers}-mysql" "php${php_vers}-zip" "php${php_vers}-xml" "php${php_vers}-intl" "php${php_vers}-mbstring" "php${php_vers}-soap" "php${php_vers}-pgsql" "php${php_vers}-ssh2"
+
+# - Change max_memory to 256M
+# - Increase max file size to 75M
+# - Increase max post size to 75M
+php_ini="/etc/php/${php_vers}/apache2/php.ini"
+grep -q '^memory_limit = 256M' "$php_ini" || sed -Ei 's/^memory_limit = [0-9]+M/memory_limit = 256M/' "$php_ini"
+grep -q '^post_max_size = 75M' "$php_ini" || sed -Ei 's/^post_max_size = [0-9]+M/post_max_size = 75M/' "$php_ini"
+grep -q '^upload_max_filesize = 75M' "$php_ini" || sed -Ei 's/^upload_max_filesize = [0-9]+M/upload_max_filesize = 75M/' "$php_ini"
+
+./samlsso_installer_debian.sh
+
+# MariaDB overrides
+cp 60-aspen.cnf /etc/mysql/mariadb.conf.d/
+
 a2enmod rewrite
-apt install -y mariadb-server
-mv /etc/mysql/mariadb.cnf /etc/mysql/mariadb.cnf.old
-cp mariadb.cnf /etc/mysql/mariadb.cnf
-systemctl start mariadb
-systemctl enable mariadb
-apt install -y software-properties-common
-apt install -y default-jdk
-apt install -y openjdk-11-jdk
-apt install -y unzip
+systemctl restart apache2 mysql
 
-#Create temp smarty directories
-cd /usr/local/aspen-discovery
-mkdir tmp
-chown -R www-data:www-data tmp
-chmod -R 755 tmp
+# Create temp smarty directories
+mkdir -p /usr/local/aspen-discovery/tmp
+chown -R www-data:www-data /usr/local/aspen-discovery/tmp
+chmod -R 755 /usr/local/aspen-discovery/tmp
 
-#Increase entropy
-apt install -y -q rng-tools
-cp install/limits.conf /etc/security/limits.conf
-cp install/rngd.service /usr/lib/systemd/system/rngd.service
+# Raise process and open file limits for the solr user
+cp solr_limits.conf /etc/security/limits.d/solr.conf
 
-systemctl daemon-reload
-systemctl start rngd
-
-apt install -y python-certbot-apache
-
-bash ./samlsso_installer_debian.sh
-
-echo "Generate new root password for mariadb at: https://passwordsgenerator.net/ and store in passbolt"
-mysql_secure_installation
-echo "Enter the timezone of the server"
-read timezone
-timedatectl set-timezone $timezone
-
-#Create aspen MySQL superuser
-read -p "Please enter the username for the Aspen MySQL superuser (can't be root) : " username
-read -p "Please enter the password for the Aspen MySQL superuser ($username) : " password
-query="GRANT ALL PRIVILEGES ON *.* TO $username@'localhost' IDENTIFIED BY '$password'";
+# Create aspen MySQL superuser
+printf "Please enter the username for the Aspen MySQL superuser (can't be root) : " >&2
+read -r username
+printf "Please enter the password for the Aspen MySQL superuser (%s) : " "$username" >&2
+read -r password
+query="GRANT ALL PRIVILEGES ON *.* TO '$username'@'localhost' IDENTIFIED BY '$password';"
 mysql -e "$query"
-query="GRANT ALL PRIVILEGES ON *.* TO $username@'127.0.0.1' IDENTIFIED BY '$password'";
+query="GRANT ALL PRIVILEGES ON *.* TO '$username'@'127.0.0.1' IDENTIFIED BY '$password';"
 mysql -e "$query"
 mysql -e "flush privileges"
 
-cd /usr/local/aspen-discovery/install
-bash ./setup_aspen_user_debian.sh
+mysql_secure_installation
+
+dpkg-reconfigure tzdata
+
+./setup_aspen_user_debian.sh

--- a/install/setup_aspen_user_debian.sh
+++ b/install/setup_aspen_user_debian.sh
@@ -1,16 +1,18 @@
 #!/bin/sh
+
+#create an aspen_apache group for files that need to be readable (and writable) by apache
+grep -q aspen_apache /etc/group || groupadd -r aspen_apache
+
+#Add www-data to the aspen_apache group
+usermod -a -G aspen_apache www-data
+
 #create a new user and user group to run Aspen Discovery
-adduser aspen
-#Add all existing users to the group
+grep -q aspen /etc/passwd || useradd -m -s /bin/bash -G aspen_apache aspen
+#Add all existing users to the aspen group
 for ID in $(cat /etc/passwd | grep /home | cut -d ':' -f1); do (usermod -a -G aspen $ID);done
 
-#create an aspen_apache group as well for files that need to be readable (and writable) by apache
-groupadd aspen_apache
-#Add www-data, aspen to the aspen_apache group
-usermod -a -G aspen_apache www-data
-usermod -a -G aspen_apache aspen
-adduser solr
-usermod -a -G aspen solr
+# Solr service user
+grep -q solr /etc/passwd || useradd -r -s /bin/bash -G aspen solr
 
 #Change file permissions so /usr/local/aspen-discovery is owned by the aspen user
 chown -R aspen:aspen /usr/local/aspen-discovery
@@ -22,9 +24,9 @@ chown -R aspen:aspen_apache /usr/local/aspen-discovery/sites/default
 chown -R solr:aspen /usr/local/aspen-discovery/sites/default/solr-7.6.0
 
 #Change file permissions so /data is owned by the aspen user
-if [[ ! -d /data/aspen-discovery ]]; then  mkdir -p /data/aspen-discovery; fi
+mkdir -p /data/aspen-discovery
 chown -R aspen:aspen_apache /data/aspen-discovery
 
 #Change file permissions so /var/log/aspen-discovery is owned by the aspen user
-if [[ ! -d /var/log/aspen-discovery ]]; then mkdir -p /var/log/aspen-discovery; fi
+mkdir -p /var/log/aspen-discovery
 chown -R aspen:aspen /var/log/aspen-discovery

--- a/install/solr_limits.conf
+++ b/install/solr_limits.conf
@@ -1,0 +1,5 @@
+# Increase process and file limits for solr user
+solr         soft    nproc           65000
+solr         soft    nofile          65000
+solr         hard    nproc           65000
+solr         hard    nofile          65000


### PR DESCRIPTION
Rather than copying whole files just make the necessary edits or use partial files for *.d/ style configs. (php and mysql config; solr security limits)

Simplify installer_debian.sh a little and make it behave better if run a second time. Also use more portable constructions for some bash-specific builtins used even though the shebang is #!/bin/sh. (user / group creation, 'read -p' vs 'printf ; read', path creation and perms)

You can't always assume #!/bin/sh is bash (it isn't on recent Debian, certainly) so a pass with shellcheck at some point would be a good idea for most shell scripts.

Signed-off-by: Jason Boyer <jboyer@equinoxOLI.org>