### PR TITLE
Adjust SSO installers

### DIFF
--- a/install/samlsso_config.sh
+++ b/install/samlsso_config.sh
@@ -16,17 +16,17 @@ if [ -z "$3" ]
     echo "Please provide a Single Sign On admin password as the third argument."
     exit 1
 fi
-if [ -z "$5" ]
+if [ -z "$4" ]
   then
-    echo "Please provide a server name as the fifth argument."
+    echo "Please provide a server name as the fourth argument."
     exit 1
 fi
 cp $sourcepath/samlsso_config.php $targetpath/config.php
 
-escape_email=$(sed 's/[^[:alnum:]]/\\&/g' <<<"$2")
-escape_timezone=$(sed 's/[^[:alnum:]]/\\&/g' <<<"$3")
-escape_adminpassword=$(sed 's/[^[:alnum:]]/\\&/g' <<<"$4")
-escape_servername=$(sed 's/[^[:alnum:]]/\\&/g' <<<"$5")
+escape_email=$(sed 's/[^[:alnum:]]/\\&/g' <<<"$1")
+escape_timezone=$(sed 's/[^[:alnum:]]/\\&/g' <<<"$2")
+escape_adminpassword=$(sed 's/[^[:alnum:]]/\\&/g' <<<"$3")
+escape_servername=$(sed 's/[^[:alnum:]]/\\&/g' <<<"$4")
 
 random_string() {
     local l=15

--- a/install/samlsso_installer_debian.sh
+++ b/install/samlsso_installer_debian.sh
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/bash 
 
  read -p "Configure SAML Single Sign On? (y/N) " SAMLSSO
  SAMLSSO="${SAMLSSO:=n}"
@@ -11,12 +11,13 @@
      read -p "Enter the SSO technical contact email: " ssoemail
      read -p "Enter a timezone (supported timezones can be found at http://php.net/manual/en/timezones.php): " ssotimezone
      read -p "Enter an SSO admin password: " ssoadminpwd
-     /bin/bash /usr/local/aspen-discovery/install/samlsso_config.sh $ssoemail $ssotimezone $ssoadminpwd
-     mkdir /etc/simplesamlphp/cert
-     mkdir /etc/simplesamlphp/log
-     mkdir /etc/simplesamlphp/data
+     read -p "Enter server name: " ssoservername
+     /usr/local/aspen-discovery/install/samlsso_config.sh $ssoemail $ssotimezone $ssoadminpwd $ssoservername
+     mkdir -p /etc/simplesamlphp/cert
+     mkdir -p /etc/simplesamlphp/log
+     mkdir -p /etc/simplesamlphp/data
      echo "Enter SAML certificate details\n"
      openssl req -newkey rsa:3072 -new -x509 -days 3652 -nodes -out /etc/simplesamlphp/cert/saml.crt -keyout /etc/simplesamlphp/cert/saml.pem
-     chgrp www-data /etc/simplesamlsso/cert/saml.pem
-     chmod 640 /etc/simplesamlsso/cert/saml.pem
+     chgrp www-data /etc/simplesamlphp/cert/saml.pem
+     chmod 640 /etc/simplesamlphp/cert/saml.pem
  fi 


### PR DESCRIPTION
SSO installation isn't working on CentOS or Debian because the config script had several off-by-one errors in its parameter handling.

Signed-off-by: Jason Boyer <jboyer@equinoxOLI.org>