### PR TITLE
Holds Messaging Updates

### DIFF
--- a/code/web/interface/themes/responsive/Record/hold-popup.tpl
+++ b/code/web/interface/themes/responsive/Record/hold-popup.tpl
@@ -21,6 +21,11 @@
 					<div id="holdError" class="pageWarning" style="display: none"></div>
 				</div>
 
+				{if $isOnHold && $rememberHoldPickupLocation}
+				<p class="alert alert-warning">
+					{translate text="This title is already on hold for you. Are you sure you want to place a duplicate hold?" isPublicFacing=true}&nbsp;
+				</p>
+				{else}
 				<p class="alert alert-info">
 					{if $pickupAt > 0}
 						{translate text="Holds allow you to request that a title be put aside for you to pick up at the library." isPublicFacing=true}&nbsp;
@@ -34,6 +39,7 @@
 						{translate text="You will then have 7 days to pick up the title from your home library." isPublicFacing=true}&nbsp;
 					{/if}
 				</p>
+				{/if}
 
 				<div id="holdOptions">
 					{assign var="onlyOnePickupLocation" value=false}

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -12216,15 +12216,14 @@ AspenDiscovery.Record = (function(){
 						} else {
 							AspenDiscovery.showMessage(data.title, data.message, false, false);
 						}
-						AspenDiscovery.Account.reloadHolds()
 					}else {
 						if (data.success) {
 							AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons);
 						} else {
 							AspenDiscovery.showMessage(data.title, data.message);
 						}
-						AspenDiscovery.Account.reloadHolds()
 					}
+					AspenDiscovery.Account.reloadHolds()
 				}).fail(AspenDiscovery.ajaxFail);
 			}else{
 				AspenDiscovery.Account.ajaxLogin(null, function(){
@@ -12323,8 +12322,14 @@ AspenDiscovery.Record = (function(){
 			requestTitleButton.prop('disabled', true);
 			requestTitleButton.addClass('disabled');
 
+			document.body.style.cursor = "wait";
 			document.querySelector('.fa-spinner').classList.remove('hidden');
 			var id = $('#id').val();
+
+			var targetButton = $('#actionButton'+id);
+			targetButton.prop('disabled', true);
+			targetButton.addClass('disabled');
+
 			var autoLogOut = $('#autologout').prop('checked');
 			var selectedItem = $('#selectedItem');
 			var module = $('#module').val();
@@ -12366,6 +12371,9 @@ AspenDiscovery.Record = (function(){
 			$("#placeHoldForm").hide();
 			$("#placingHoldMessage").show();
 			$.getJSON(Globals.path + "/" + module +  "/" + id + "/AJAX", params, function(data){
+				document.body.style.cursor = "default";
+				targetButton.prop('disabled', false);
+				targetButton.removeClass('disabled');
 				if (data.success){
 					if (data.needsItemLevelHold){
 						var requestTitleButton = $('#requestTitleButton');
@@ -12389,6 +12397,7 @@ AspenDiscovery.Record = (function(){
 				}else{
 					AspenDiscovery.showMessage(data.title, data.message, false, false);
 				}
+				AspenDiscovery.Account.reloadHolds()
 			}).fail(AspenDiscovery.ajaxFail);
 		},
 

--- a/code/web/interface/themes/responsive/js/aspen/record.js
+++ b/code/web/interface/themes/responsive/js/aspen/record.js
@@ -30,15 +30,14 @@ AspenDiscovery.Record = (function(){
 						} else {
 							AspenDiscovery.showMessage(data.title, data.message, false, false);
 						}
-						AspenDiscovery.Account.reloadHolds()
 					}else {
 						if (data.success) {
 							AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons);
 						} else {
 							AspenDiscovery.showMessage(data.title, data.message);
 						}
-						AspenDiscovery.Account.reloadHolds()
 					}
+					AspenDiscovery.Account.reloadHolds()
 				}).fail(AspenDiscovery.ajaxFail);
 			}else{
 				AspenDiscovery.Account.ajaxLogin(null, function(){
@@ -137,8 +136,14 @@ AspenDiscovery.Record = (function(){
 			requestTitleButton.prop('disabled', true);
 			requestTitleButton.addClass('disabled');
 
+			document.body.style.cursor = "wait";
 			document.querySelector('.fa-spinner').classList.remove('hidden');
 			var id = $('#id').val();
+
+			var targetButton = $('#actionButton'+id);
+			targetButton.prop('disabled', true);
+			targetButton.addClass('disabled');
+
 			var autoLogOut = $('#autologout').prop('checked');
 			var selectedItem = $('#selectedItem');
 			var module = $('#module').val();
@@ -180,6 +185,9 @@ AspenDiscovery.Record = (function(){
 			$("#placeHoldForm").hide();
 			$("#placingHoldMessage").show();
 			$.getJSON(Globals.path + "/" + module +  "/" + id + "/AJAX", params, function(data){
+				document.body.style.cursor = "default";
+				targetButton.prop('disabled', false);
+				targetButton.removeClass('disabled');
 				if (data.success){
 					if (data.needsItemLevelHold){
 						var requestTitleButton = $('#requestTitleButton');
@@ -203,6 +211,7 @@ AspenDiscovery.Record = (function(){
 				}else{
 					AspenDiscovery.showMessage(data.title, data.message, false, false);
 				}
+				AspenDiscovery.Account.reloadHolds()
 			}).fail(AspenDiscovery.ajaxFail);
 		},
 

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -205,6 +205,10 @@ class Record_AJAX extends Action {
 			require_once ROOT_DIR . '/RecordDrivers/MarcRecordDriver.php';
 			$marcRecord = new MarcRecordDriver($id);
 
+			require_once ROOT_DIR . '/sys/Account/User.php';
+			$isOnHold = $user->isRecordOnHold($recordSource, $id);
+			$interface->assign('isOnHold', $isOnHold);
+
 			if (!$this->setupHoldForm($recordSource, $rememberHoldPickupLocation, $marcRecord, $locations)) {
 				return [
 					'holdFormBypassed' => false,
@@ -282,7 +286,7 @@ class Record_AJAX extends Action {
 				}
 			}
 
-			if ($bypassHolds) {
+			if ($bypassHolds && !$isOnHold) {
 				if (strpos($id, ':') !== false) {
 					[
 						,
@@ -400,10 +404,17 @@ class Record_AJAX extends Action {
 					'success' => true,
 				];
 				if ($holdType != 'none') {
-					$results['modalButtons'] = "<button type='submit' name='submit' id='requestTitleButton' class='btn btn-primary' onclick='return AspenDiscovery.Record.submitHoldForm();'><i class='fas fa-spinner fa-spin hidden' role='status' aria-hidden='true'></i>&nbsp;" . translate([
-							'text' => "Submit Hold Request",
-							'isPublicFacing' => true,
-						]) . "</button>";
+					if ($isOnHold){
+						$results['modalButtons'] = "<button type='submit' name='submit' id='requestTitleButton' class='btn btn-primary' onclick='return AspenDiscovery.Record.submitHoldForm();'><i class='fas fa-spinner fa-spin hidden' role='status' aria-hidden='true'></i>&nbsp;" . translate([
+								'text' => "Yes, Place Hold",
+								'isPublicFacing' => true,
+							]) . "</button>";
+					}else{
+						$results['modalButtons'] = "<button type='submit' name='submit' id='requestTitleButton' class='btn btn-primary' onclick='return AspenDiscovery.Record.submitHoldForm();'><i class='fas fa-spinner fa-spin hidden' role='status' aria-hidden='true'></i>&nbsp;" . translate([
+								'text' => "Submit Hold Request",
+								'isPublicFacing' => true,
+							]) . "</button>";
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
- Add popup for when title is already on hold for user to confirm placing a duplicate hold. 
- Disable hold button for when user submits hold form through the modal and reloadHolds when action is taken 
- Made requested changes, confirmed with QA that we want to prompt for placing duplicate holds on item & volume level holds