### PR TITLE
Fixes Hunter's Lane Student Report

### DIFF
--- a/code/web/services/Report/StudentReport.php
+++ b/code/web/services/Report/StudentReport.php
@@ -23,7 +23,7 @@ class Report_StudentReport extends Admin_Admin {
 		}
 		asort($locationLookupList);
 		$interface->assign('locationLookupList', $locationLookupList);
-		$selectedLocation = isset($_REQUEST['location']) ? $_REQUEST['location'] : reset($locationLookupList);
+		$selectedLocation = isset($_REQUEST['location']) ? $_REQUEST['location'] : '';
 		$interface->assign('selectedLocation', $selectedLocation);
 // OTHER FORM VARIABLES
 		$showOverdueOnly = isset($_REQUEST['showOverdueOnly']) ? $_REQUEST['showOverdueOnly'] : 'overdue';


### PR DESCRIPTION
Two school libraries with apostrophes (Hunter's Lane and Neely's Bend) tripped an error on the Student Overdue Report