### PR TITLE
Small Changes to Hold Form Bypass

### DIFF
--- a/code/web/interface/themes/responsive/Record/hold-popup.tpl
+++ b/code/web/interface/themes/responsive/Record/hold-popup.tpl
@@ -21,7 +21,7 @@
 					<div id="holdError" class="pageWarning" style="display: none"></div>
 				</div>
 
-				{if $isOnHold && $rememberHoldPickupLocation}
+				{if $isOnHold}
 				<p class="alert alert-warning">
 					{translate text="This title is already on hold for you. Are you sure you want to place a duplicate hold?" isPublicFacing=true}&nbsp;
 				</p>

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -12208,17 +12208,19 @@ AspenDiscovery.Record = (function(){
 							if (data.needsItemLevelHold){
 								AspenDiscovery.showMessageWithButtons(data.title, data.message, data.modalButtons);
 							}else {
-								AspenDiscovery.showMessage(data.title, data.message, false, true);
+								document.getElementById('actionButton'+id).innerHTML = data.newHoldButtonText;
+								AspenDiscovery.showMessage(data.title, data.message, false, false);
 								AspenDiscovery.Account.loadMenuData();
 							}
 						}else if (data.confirmationNeeded){
 							AspenDiscovery.showMessageWithButtons(data.title, data.message, data.modalButtons);
 						} else {
-							AspenDiscovery.showMessage(data.title, data.message, false, true);
+							document.getElementById('actionButton'+id).innerHTML = data.newHoldButtonText;
+							AspenDiscovery.showMessage(data.title, data.message, false, false);
 						}
 					}else {
 						if (data.success) {
-							AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons, true);
+							AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons, false);
 						} else {
 							AspenDiscovery.showMessage(data.title, data.message);
 						}
@@ -12388,6 +12390,7 @@ AspenDiscovery.Record = (function(){
 						AspenDiscovery.showMessageWithButtons(data.title, data.message, data.modalButtons);
 					}else{
 						AspenDiscovery.showMessage(data.title, data.message, false, data.autologout);
+						document.getElementById('actionButton'+id).innerHTML = data.newHoldButtonText;
 						if (!data.autologout){
 							AspenDiscovery.Account.loadMenuData();
 						}

--- a/code/web/interface/themes/responsive/js/aspen/record.js
+++ b/code/web/interface/themes/responsive/js/aspen/record.js
@@ -22,17 +22,19 @@ AspenDiscovery.Record = (function(){
 							if (data.needsItemLevelHold){
 								AspenDiscovery.showMessageWithButtons(data.title, data.message, data.modalButtons);
 							}else {
-								AspenDiscovery.showMessage(data.title, data.message, false, true);
+								document.getElementById('actionButton'+id).innerHTML = data.newHoldButtonText;
+								AspenDiscovery.showMessage(data.title, data.message, false, false);
 								AspenDiscovery.Account.loadMenuData();
 							}
 						}else if (data.confirmationNeeded){
 							AspenDiscovery.showMessageWithButtons(data.title, data.message, data.modalButtons);
 						} else {
-							AspenDiscovery.showMessage(data.title, data.message, false, true);
+							document.getElementById('actionButton'+id).innerHTML = data.newHoldButtonText;
+							AspenDiscovery.showMessage(data.title, data.message, false, false);
 						}
 					}else {
 						if (data.success) {
-							AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons, true);
+							AspenDiscovery.showMessageWithButtons(data.title, data.modalBody, data.modalButtons, false);
 						} else {
 							AspenDiscovery.showMessage(data.title, data.message);
 						}
@@ -202,6 +204,7 @@ AspenDiscovery.Record = (function(){
 						AspenDiscovery.showMessageWithButtons(data.title, data.message, data.modalButtons);
 					}else{
 						AspenDiscovery.showMessage(data.title, data.message, false, data.autologout);
+						document.getElementById('actionButton'+id).innerHTML = data.newHoldButtonText;
 						if (!data.autologout){
 							AspenDiscovery.Account.loadMenuData();
 						}

--- a/code/web/release_notes/23.02.00.MD
+++ b/code/web/release_notes/23.02.00.MD
@@ -14,13 +14,13 @@
   - Primary Configuration > Library Systems > ILS / Account Integration > Opting out of Reading History Updates ILS settings
 
   - Disable hold button while Aspen is processing placing the hold (Tickets 102832, 105156, 107370, 107474)
-  - Reload holds after a hold is placed so "On Hold For %1%" button displays properly (Tickets 102832, 105156, 107370, 107474)
+  - Update "Place Hold" button to "On Hold For %1%" after a hold is successfully placed (Tickets 102832, 105156, 107370, 107474)
   - Add confirmation modal for placing duplicate holds
   - Allow reading history to be disabled by Patron Type. (Ticket 106458)
   - **New Settings**
-- Primary Configuration > Library Systems > ILS / Account Integration > Opting in to Reading History Updates ILS settings
+  - Primary Configuration > Library Systems > ILS / Account Integration > Opting in to Reading History Updates ILS settings
 
-  - Hide areas of Linked Accounts page if patron does not have needed permissions to take those actions
+    - Hide areas of Linked Accounts page if patron does not have needed permissions to take those actions
 
 ### Axis360 Integration
 - Ensure titles are properly deleted when they are no longer marked active within Axis 360. (Ticket 108916)

--- a/code/web/services/Record/AJAX.php
+++ b/code/web/services/Record/AJAX.php
@@ -292,8 +292,11 @@ class Record_AJAX extends Action {
 			}
 
 			//If the title is on hold for the user set $byPassHolds to false
+			if ($isOnHold) {
+				$bypassHolds = false;
+			}
 
-			if ($bypassHolds && !$isOnHold) {
+			if ($bypassHolds) {
 				if (strpos($id, ':') !== false) {
 					[
 						,
@@ -824,6 +827,7 @@ class Record_AJAX extends Action {
 							'success' => $return['success'],
 							'message' => $interface->fetch('Record/hold-success-popup.tpl'),
 							'title' => $return['title'] ?? '',
+							'newHoldButtonText' => $return['newHoldButtonText'],
 							'confirmationNeeded' => $confirmationNeeded,
 						];
 						if ($confirmationNeeded) {

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -1859,7 +1859,19 @@ class User extends DataObject {
 	function placeHold($recordId, $pickupBranch, $cancelDate = null) {
 		$result = $this->getCatalogDriver()->placeHold($this, $recordId, $pickupBranch, $cancelDate);
 		$this->updateAltLocationForHold($pickupBranch);
+		$thisUser = translate([
+			'text' => 'You',
+			'isPublicFacing' => true,
+		]);
+		if (!empty($this->parentUser)){
+			$thisUser = $this->displayName;
+		}
 		if ($result['success']) {
+			$result['newHoldButtonText'] = translate([
+				'text' => 'On Hold for %1%',
+				1 => $thisUser,
+				'isPublicFacing' => true,
+			]);
 			$this->clearCache();
 		}
 		return $result;
@@ -1868,7 +1880,19 @@ class User extends DataObject {
 	function placeVolumeHold($recordId, $volumeId, $pickupBranch) {
 		$result = $this->getCatalogDriver()->placeVolumeHold($this, $recordId, $volumeId, $pickupBranch);
 		$this->updateAltLocationForHold($pickupBranch);
+		$thisUser = translate([
+			'text' => 'You',
+			'isPublicFacing' => true,
+		]);
+		if (!empty($this->parentUser)){
+			$thisUser = $this->displayName;
+		}
 		if ($result['success']) {
+			$result['newHoldButtonText'] = translate([
+				'text' => 'On Hold for %1%',
+				1 => $thisUser,
+				'isPublicFacing' => true,
+			]);
 			$this->clearCache();
 		}
 		return $result;
@@ -1921,7 +1945,19 @@ class User extends DataObject {
 	function placeItemHold($recordId, $itemId, $pickupBranch, $cancelDate = null) {
 		$result = $this->getCatalogDriver()->placeItemHold($this, $recordId, $itemId, $pickupBranch, $cancelDate);
 		$this->updateAltLocationForHold($pickupBranch);
+		$thisUser = translate([
+			'text' => 'You',
+			'isPublicFacing' => true,
+		]);
+		if (!empty($this->parentUser)){
+			$thisUser = $this->displayName;
+		}
 		if ($result['success']) {
+			$result['newHoldButtonText'] = translate([
+				'text' => 'On Hold for %1%',
+				1 => $thisUser,
+				'isPublicFacing' => true,
+			]);
 			$this->clearCache();
 		}
 		return $result;


### PR DESCRIPTION
- If title is on hold, mark $bypassHolds as false so hold form popup will show 
- If title is on hold, let patron know in modal that it is on hold (whether they have "remember my pickup location" on or off) 
- Change text for "Place Hold" button after hold is successfully placed. This will show the translated value for "On Hold for %1%" and "You" and will show the username instead of "You" if it is a linked account 
- Updated release notes to reflect changes (no more page refresh)