### PR TITLE
Fix for blank home link

### DIFF
--- a/code/web/sys/Interface.php
+++ b/code/web/sys/Interface.php
@@ -470,7 +470,7 @@ class UInterface extends Smarty {
 			$this->assign('homeLink', $location->homeLink);
 		} elseif (strlen($library->homeLink) > 0 && $library->homeLink != 'default') {
 			$this->assign('homeLink', $library->homeLink);
-		} elseif ($library->homeLink == 'default') {
+		} elseif ($library->homeLink == 'default' || $library->homeLink == null || $library->homeLink == 0) {
 			$this->assign('homeLink', '/');
 		}
 

--- a/code/web/sys/Interface.php
+++ b/code/web/sys/Interface.php
@@ -470,7 +470,7 @@ class UInterface extends Smarty {
 			$this->assign('homeLink', $location->homeLink);
 		} elseif (strlen($library->homeLink) > 0 && $library->homeLink != 'default') {
 			$this->assign('homeLink', $library->homeLink);
-		} elseif ($library->homeLink == 'default' || $library->homeLink == null || $library->homeLink == 0) {
+		} elseif ($library->homeLink == 'default' || empty($library->homeLink)) {
 			$this->assign('homeLink', '/');
 		}
 


### PR DESCRIPTION
ccfls received a smarty error because they had an empty home link instead of '/'. Their homeLink for the library system was blank, changing it to 'default' fixed the error. This should set it to be '/' if homeLink is blank