### PR TITLE
Holds Messaging

### DIFF
--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -6031,6 +6031,7 @@ AspenDiscovery.Account = (function () {
 					AspenDiscovery.Account.cancelHold(patronId, recordId, holdIdToCancel, isIll)
 				}, false);
 			}
+			AspenDiscovery.Account.reloadHolds();
 
 			return false
 		},
@@ -6058,6 +6059,7 @@ AspenDiscovery.Account = (function () {
 				this.ajaxLogin(null, this.cancelHoldSelectedTitles, true);
 				//auto close so that if user opts out of canceling, the login window closes; if the users continues, follow-up operations will reopen modal
 			}
+			AspenDiscovery.Account.reloadHolds();
 			return false
 		},
 
@@ -6081,6 +6083,7 @@ AspenDiscovery.Account = (function () {
 				this.ajaxLogin(null, this.cancelHoldAll, true);
 				//auto close so that if user opts out of canceling, the login window closes; if the users continues, follow-up operations will reopen modal
 			}
+			AspenDiscovery.Account.reloadHolds();
 			return false;
 		},
 

--- a/code/web/interface/themes/responsive/js/aspen/account.js
+++ b/code/web/interface/themes/responsive/js/aspen/account.js
@@ -766,6 +766,7 @@ AspenDiscovery.Account = (function () {
 					AspenDiscovery.Account.cancelHold(patronId, recordId, holdIdToCancel, isIll)
 				}, false);
 			}
+			AspenDiscovery.Account.reloadHolds();
 
 			return false
 		},
@@ -793,6 +794,7 @@ AspenDiscovery.Account = (function () {
 				this.ajaxLogin(null, this.cancelHoldSelectedTitles, true);
 				//auto close so that if user opts out of canceling, the login window closes; if the users continues, follow-up operations will reopen modal
 			}
+			AspenDiscovery.Account.reloadHolds();
 			return false
 		},
 
@@ -816,6 +818,7 @@ AspenDiscovery.Account = (function () {
 				this.ajaxLogin(null, this.cancelHoldAll, true);
 				//auto close so that if user opts out of canceling, the login window closes; if the users continues, follow-up operations will reopen modal
 			}
+			AspenDiscovery.Account.reloadHolds();
 			return false;
 		},
 


### PR DESCRIPTION
Refresh holds after cancelling a hold. Fix for titles no longer showing "on hold for you" after cancelling a duplicate hold