### PR TITLE
DB Update

### DIFF
--- a/code/web/release_notes/23.02.01.MD
+++ b/code/web/release_notes/23.02.01.MD
@@ -14,3 +14,4 @@
 - Updates for migrating data between servers (Ticket 106504)
 - Return 404 errors for events that no longer exist.
 - PHP 8 / Smarty updates
+- Update user list entries that have no title in the database (Ticket 97113)

--- a/code/web/sys/DBMaintenance/version_updates/23.02.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.02.00.php
@@ -257,7 +257,8 @@ function getUpdates23_02_00(): array {
 			'sql' => [
 				"UPDATE user_list_entry 
     			INNER JOIN grouped_work ON user_list_entry.sourceId = grouped_work.permanent_id 	
-				SET user_list_entry.title = grouped_work.full_title WHERE user_list_entry.title = ''"
+				SET user_list_entry.title = grouped_work.full_title WHERE user_list_entry.title = ''
+				AND user_list_entry.source = 'GroupedWork'"
 			]
 		],
 		//update_list_entry_titles

--- a/code/web/sys/DBMaintenance/version_updates/23.02.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.02.00.php
@@ -257,7 +257,7 @@ function getUpdates23_02_00(): array {
 			'sql' => [
 				"UPDATE user_list_entry 
     			INNER JOIN grouped_work ON user_list_entry.sourceId = grouped_work.permanent_id 	
-				SET user_list_entry.title = grouped_work.full_title WHERE user_list_entry.title = ''
+				SET user_list_entry.title = LEFT(grouped_work.full_title, 50) WHERE user_list_entry.title = ''
 				AND user_list_entry.source = 'GroupedWork'"
 			]
 		],

--- a/code/web/sys/DBMaintenance/version_updates/23.02.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.02.00.php
@@ -251,6 +251,16 @@ function getUpdates23_02_00(): array {
 			]
 		],
 		//set_include_econtent_and_onorder
+		'update_list_entry_titles' => [
+			'title' => 'Update List Entry Titles',
+			'description' => 'Update list entry titles for entries with no title in the database',
+			'sql' => [
+				"UPDATE user_list_entry 
+    			INNER JOIN grouped_work ON user_list_entry.sourceId = grouped_work.permanent_id 	
+				SET user_list_entry.title = grouped_work.full_title WHERE user_list_entry.title = ''"
+			]
+		],
+		//update_list_entry_titles
 
 		//james
         'account_link_remove_setting_by_ptype' => [


### PR DESCRIPTION
- Updates list entry titles that are empty strings to the title of their corresponding grouped work (fix for imported lists) 
- Checked DB and title was empty string, not NULL
- Tested on my local machine
- Update release notes