### PR TITLE
Show All Variation Formats

### DIFF
--- a/code/web/RecordDrivers/GroupedWorkDriver.php
+++ b/code/web/RecordDrivers/GroupedWorkDriver.php
@@ -1658,7 +1658,6 @@ class GroupedWorkDriver extends IndexRecordDriver {
 			return null;
 		}
 	}
-
 	public function getScrollerTitle($index, $scrollerName) {
 		global $interface;
 		$interface->assign('index', $index);
@@ -2590,7 +2589,7 @@ class GroupedWorkDriver extends IndexRecordDriver {
 							$thisVariation = $item['groupedWorkVariationId'];
 							foreach ($allVariations as $variation) {
 								if ($thisVariation == $variation->databaseId) {
-									$recordVariations[] = $variation;
+									$recordVariations[$variation->manifestation->format] = $variation;
 								}
 							}
 						}
@@ -2607,6 +2606,7 @@ class GroupedWorkDriver extends IndexRecordDriver {
 							$relatedRecord = new Grouping_Record($recordId, $record, $recordDriver, $volumeData, $record['source'], true);
 
 							$relatedRecord->variationFormat = $variation->manifestation->format;
+							$relatedRecord->recordVariations = $recordVariations;
 
 							$relatedRecords[$relatedRecord->id] = $relatedRecord;
 							$allRecords[$relatedRecord->databaseId . ':' . $variation->manifestation->format] = $relatedRecord;

--- a/code/web/RecordDrivers/MarcRecordDriver.php
+++ b/code/web/RecordDrivers/MarcRecordDriver.php
@@ -943,6 +943,12 @@ class MarcRecordDriver extends GroupedWorkSubDriver {
 		} else {
 			$relatedRecord = $groupedWorkDriver->getRelatedRecord($this->getIdWithSource());
 			if ($relatedRecord != null) {
+				if (count($relatedRecord->recordVariations) > 1){
+					foreach ($relatedRecord->recordVariations as $variation){
+						$formats[] = $variation->manifestation->format;
+					}
+					return $formats;
+				}
 				return [$relatedRecord->format];
 			} else {
 				$recordDetails = $this->getGroupedWorkDriver()->getSolrField('record_details');

--- a/code/web/sys/Grouping/Record.php
+++ b/code/web/sys/Grouping/Record.php
@@ -16,6 +16,7 @@ class Grouping_Record {
 	public $physical;
 	public $closedCaptioned;
 	public $variationFormat;
+	public $recordVariations;
 	public $hasParentRecord;
 	public $hasChildRecord;
 


### PR DESCRIPTION
Adds $recordVariations to $relatedRecord(s) so we can check all formats for a record and display them on the marc record page. If there is only one variation (one format), then we just use the $relatedRecord->format as usual.