### PR TITLE
Linked accounts: disable disable

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/linkedAccounts.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/linkedAccounts.tpl
@@ -47,7 +47,7 @@
 								<li>{translate text="None" isPublicFacing=true}</li>
 							{/foreach}
 						</ul>
-						<button class="btn btn-sm btn-danger" onclick="AspenDiscovery.Account.disableAccountLinkingPopup()">{translate text="Disable Account Linking" isPublicFacing=true}</button>
+						{if $linkRemoveSetting != 0}<button class="btn btn-sm btn-danger" onclick="AspenDiscovery.Account.disableAccountLinkingPopup()">{translate text="Disable Account Linking" isPublicFacing=true}</button>{if $linkRemoveSetting != 0}
 					{/if}
 				{else}
 					{if $linkSetting == 3}


### PR DESCRIPTION
For patrons with patron type that do not have permission "Allow users to remove managing account links", do not show "Disable Account Linking" button