### PR TITLE
Remove "runuser" from debian upgrade script

### DIFF
--- a/data_dir_setup/update_solr_files_debian.sh
+++ b/data_dir_setup/update_solr_files_debian.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Copies needed solr files to the server specified as a command line argument
+# This script is intended to be run as root
+if [ -z "$1" ]
+  then
+    echo "Please provide the server name to update as the first argument."
+fi
+echo "Updating $1"
+
+cp -r solr7 /data/aspen-discovery/$1
+chown -R solr:aspen /data/aspen-discovery/$1/solr7
+
+su -c "/usr/local/aspen-discovery/sites/$1/$1.sh restart" solr

--- a/install/upgrade_debian.sh
+++ b/install/upgrade_debian.sh
@@ -29,7 +29,7 @@ pkill java
 sudo service mysqld restart
 apachectl restart
 cd /usr/local/aspen-discovery/data_dir_setup
-/usr/local/aspen-discovery/data_dir_setup/update_solr_files.sh $1
+/usr/local/aspen-discovery/data_dir_setup/update_solr_files_debian.sh $1
 
 cd /usr/local/aspen-discovery
 git gc


### PR DESCRIPTION
This points the debian install script to a new "update_solr_files" script in data_dir_setup exclusively for debian that replaces "runuser" with "su -c ''user"