### PR TITLE
Fix Git dubious ownersip errors when pulling

### DIFF
--- a/install/upgrade_debian.sh
+++ b/install/upgrade_debian.sh
@@ -13,6 +13,7 @@ fi
 
 service cron stop
 
+git config --global --add safe.directory /usr/local/aspen-discovery
 cd /usr/local/aspen-discovery
 git pull origin $2
 


### PR DESCRIPTION
In more recent versions of git when upgrading Aspen and pulling the new branch git will throw an error due to having many different owners of the directories inside /usr/local/aspen-discovery. This tells git to ignore the ownership and pull anyway