### PR TITLE
Fix frozen holds date format to 'M d, Y'

### DIFF
--- a/code/web/Drivers/Evergreen.php
+++ b/code/web/Drivers/Evergreen.php
@@ -796,7 +796,7 @@ class Evergreen extends AbstractIlsDriver {
 							$curHold->status = "Frozen";
 							$curHold->canFreeze = true;
 							if ($holdInfo['thaw_date'] != null) {
-								$curHold->status .= ' until ' . date("m/d/Y", strtotime($holdInfo['thaw_date']));
+								$curHold->status .= ' until ' . date("M d, Y", strtotime($holdInfo['thaw_date']));
 							}
 							$curHold->locationUpdateable = true;
 						} elseif (!empty($holdInfo['shelf_time'])) {

--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -1979,7 +1979,7 @@ class Koha extends AbstractIlsDriver {
 				$curHold->status = "Frozen";
 				$curHold->canFreeze = true;
 				if ($curRow['suspend_until'] != null) {
-					$curHold->status .= ' until ' . date("m/d/Y", strtotime($curRow['suspend_until']));
+					$curHold->status .= ' until ' . date("M d, Y", strtotime($curRow['suspend_until']));
 				}
 				$curHold->locationUpdateable = true;
 				if($this->getKohaVersion() >= 22.11) {

--- a/code/web/Drivers/OverDriveDriver.php
+++ b/code/web/Drivers/OverDriveDriver.php
@@ -723,7 +723,7 @@ class OverDriveDriver extends AbstractEContentDriver {
 						$hold->status = "Frozen";
 						if ($curTitle->holdSuspension->numberOfDays > 0) {
 							$numDaysSuspended = $curTitle->holdSuspension->numberOfDays;
-							$hold->status .= ' until ' . DateUtils::addDays(date('m/d/Y'), $numDaysSuspended, "m/d/Y");
+							$hold->status .= ' until ' . DateUtils::addDays(date('m/d/Y'), $numDaysSuspended, "M d,Y");
 						}
 					}
 				}


### PR DESCRIPTION
This changes the displayed date format for frozen holds for the Koha, Evergreen and OverDrive Drivers in 'code/web/Drivers/' allowing them to be read correctly internationally.