### PR TITLE
Trim Strings for Events (facet search fix)

### DIFF
--- a/code/events_indexer/src/com/turning_leaf_technologies/events/CommunicoIndexer.java
+++ b/code/events_indexer/src/com/turning_leaf_technologies/events/CommunicoIndexer.java
@@ -1,5 +1,6 @@
 package com.turning_leaf_technologies.events;
 
+import com.turning_leaf_technologies.strings.AspenStringUtils;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpEntity;
 import org.apache.http.StatusLine;
@@ -211,7 +212,7 @@ class CommunicoIndexer {
 							solrDocument.addField("title", fullTitle);
 						}
 
-						solrDocument.addField("branch", curEvent.getString("locationName"));
+						solrDocument.addField("branch", AspenStringUtils.trimTrailingPunctuation(curEvent.getString("locationName")));
 
 						if (curEvent.isNull("eventType")) {
 							solrDocument.addField("event_type", "Undefined");
@@ -223,7 +224,7 @@ class CommunicoIndexer {
 						if (curEvent.isNull("roomName")){
 							solrDocument.addField("room", "");
 						}else{
-							solrDocument.addField("room", curEvent.getString("roomName"));
+							solrDocument.addField("room", AspenStringUtils.trimTrailingPunctuation(curEvent.getString("roomName")));
 						}
 
 						solrDocument.addField("age_group", getNameStringsForKeyCommunico(curEvent, "ages"));

--- a/code/events_indexer/src/com/turning_leaf_technologies/events/LibraryMarketLibraryCalendarIndexer.java
+++ b/code/events_indexer/src/com/turning_leaf_technologies/events/LibraryMarketLibraryCalendarIndexer.java
@@ -1,5 +1,6 @@
 package com.turning_leaf_technologies.events;
 
+import com.turning_leaf_technologies.strings.AspenStringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
 import org.apache.http.StatusLine;
@@ -355,12 +356,13 @@ class LibraryMarketLibraryCalendarIndexer {
 			if (curEvent.get(keyName) instanceof JSONObject) {
 				JSONObject keyObj = curEvent.getJSONObject(keyName);
 				for (String keyValue : keyObj.keySet()) {
-					values.add(keyObj.getString(keyValue));
+					values.add(AspenStringUtils.trimTrailingPunctuation(keyObj.getString(keyValue)));
 				}
 			}else{
 				JSONArray keyArray = curEvent.getJSONArray(keyName);
 				for (int i = 0; i < keyArray.length(); i++){
-					values.add(keyArray.getString(i));
+					String value = AspenStringUtils.trimTrailingPunctuation(keyArray.getString(i));
+					values.add(value);
 				}
 			}
 		}

--- a/code/events_indexer/src/com/turning_leaf_technologies/events/SpringshareLibCalIndexer.java
+++ b/code/events_indexer/src/com/turning_leaf_technologies/events/SpringshareLibCalIndexer.java
@@ -1,5 +1,6 @@
 package com.turning_leaf_technologies.events;
 
+import com.turning_leaf_technologies.strings.AspenStringUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
 import org.apache.http.StatusLine;
@@ -240,8 +241,8 @@ class SpringshareLibCalIndexer {
 						solrDocument.addField("event_month", eventMonths);
 						solrDocument.addField("event_year", eventYears);
 						solrDocument.addField("title", curEvent.getString("title"));
-						solrDocument.addField("branch", getNameStringForKeyLibCal(curEvent, "campus"));
-						solrDocument.addField("room", getNameStringForKeyLibCal(curEvent, "location"));
+						solrDocument.addField("branch", AspenStringUtils.trimTrailingPunctuation(getNameStringForKeyLibCal(curEvent, "campus")));
+						solrDocument.addField("room", AspenStringUtils.trimTrailingPunctuation(getNameStringForKeyLibCal(curEvent, "location")));
 						/* // LibCal events do not have a field for offsite_address
 						solrDocument.addField("offsite_address", getStringForKeyLibCal(curEvent, "offsite_address"));
 						*/


### PR DESCRIPTION
Trim strings for branch and room names for events where applicable. 

In SpringshareLibCalIndexer.java - didn't add trimTrailingPunctuation() to getNameStringForKeyLibcal() because we use that to get the description - added it to the individual places where we add branch and room instead