### PR TITLE
Communico Updates

### DIFF
--- a/code/events_indexer/src/com/turning_leaf_technologies/events/CommunicoIndexer.java
+++ b/code/events_indexer/src/com/turning_leaf_technologies/events/CommunicoIndexer.java
@@ -69,6 +69,9 @@ class CommunicoIndexer {
 		if (this.baseUrl.endsWith("/")) {
 			this.baseUrl = this.baseUrl.substring(0, this.baseUrl.length() - 1);
 		}
+		if (this.baseUrl.endsWith("events")) {
+			this.baseUrl = this.baseUrl.substring(0, this.baseUrl.length() - 1);
+		}
 		this.clientId = clientId;
 		this.clientSecret = clientSecret;
 		this.aspenConn = aspenConn;

--- a/code/web/RecordDrivers/CommunicoEventRecordDriver.php
+++ b/code/web/RecordDrivers/CommunicoEventRecordDriver.php
@@ -154,8 +154,8 @@ class CommunicoEventRecordDriver extends IndexRecordDriver {
 
 	function getEventCoverUrl() {
 		$decodedData = $this->getEventObject()->getDecodedData();
-		if (!empty($decodedData->image)) {
-			return $decodedData->image;
+		if (!empty($decodedData->eventImage)) {
+			return $decodedData->eventImage;
 		}
 		return null;
 	}

--- a/code/web/interface/themes/responsive/Communico/event.tpl
+++ b/code/web/interface/themes/responsive/Communico/event.tpl
@@ -2,9 +2,11 @@
 	<div class="row">
 		<div class="col-sm-4">
 			<div class="panel active">
+				{if (!empty($recordDriver->getEventCoverUrl()))}
 				<div class="panel-body">
 					<a href="{$recordDriver->getLinkUrl()}"><img class="img-responsive img-thumbnail {$coverStyle}" src="{$recordDriver->getEventCoverUrl()}" alt="{$recordDriver->getTitle()|escape}"></a>
 				</div>
+				{/if}
 			</div>
 			{if !empty($recordDriver->getAudiences())}
 				<div class="panel active">
@@ -37,7 +39,15 @@
 				</a>
 			<br></br>
 		</div>
-		<div class="col-sm-8">
+		{*If there is no image we need to make a new row to display properly*}
+		{*A new row causes incorrect displays if there is an image*}
+		{if (empty($recordDriver->getEventCoverUrl()))}
+	</div>
+	<div class="row">
+		<div class="col-sm-offset-4 col-sm-8">
+			{else}
+			<div class="col-sm-8">
+			{/if}
 			{$recordDriver->getDescription()}
 			<br></br>
 			{$recordDriver->getFullDescription()}

--- a/code/web/interface/themes/responsive/Events/share-tools.tpl
+++ b/code/web/interface/themes/responsive/Events/share-tools.tpl
@@ -3,7 +3,7 @@
 	<div class="share-tools">
 		<span class="share-tools-label hidden-inline-xs">{translate text="SHARE" isPublicFacing=true}</span>
 		{if !empty($showShareOnExternalSites)}
-			<a href="http://www.facebook.com/sharer/sharer.php?u={$eventUrl|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true isPublicFacing=true}">
+		<a href="http://www.facebook.com/sharer/sharer.php?u={$url}/{$eventUrl|escape:'url'}" target="_blank" title="{translate text="Share on Facebook" inAttribute=true}" aria-label="Share on Facebook">
 				<i class="fab fa-facebook-square fa-2x fa-fw"></i>
 			</a>
 

--- a/code/web/sys/Events/CommunicoSetting.php
+++ b/code/web/sys/Events/CommunicoSetting.php
@@ -38,14 +38,14 @@ class CommunicoSetting extends DataObject {
 			'baseUrl' => [
 				'property' => 'baseUrl',
 				'type' => 'url',
-				'label' => 'Base URL (i.e. https://yoursite.libcal.com)',
+				'label' => 'Base URL (i.e. https://attend.yoursite.com/events)',
 				'description' => 'The URL for the site',
 			],
 			'clientId' => [
 				'property' => 'clientId',
 				'type' => 'text',
-				'label' => 'Client ID',
-				'description' => 'Client ID',
+				'label' => 'Client Key',
+				'description' => 'Client Key',
 			],
 			'clientSecret' => [
 				'property' => 'clientSecret',


### PR DESCRIPTION
- Cut off the "s" at the end of the url for events for communico for individual event indexing (we want event/38823 instead of events/38823) 
- Update the display page for events that have no image 
- Update language around Communico settings to match the language they use 
- Update getEventCoverUrl to actually fetch the event image :)