### PR TITLE
Default weight on (library|location)_records_to_include

### DIFF
--- a/code/web/sys/DBMaintenance/version_updates/23.04.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.04.00.php
@@ -262,6 +262,15 @@ function getUpdates23_04_00(): array {
 				)',
 			],
 		],
+		// Set default weight for (library|location)_records_to_include to 0
+		'default_records_to_include_weight' => [
+			'title' => 'Default Value for Records to Include Weight',
+			'description' => 'Add a default of 0 for weight in the library_records_to_include and location_records_to_include tables',
+			'sql' => [
+				'ALTER TABLE library_records_to_include ALTER COLUMN weight SET DEFAULT 0',
+				'ALTER TABLE location_records_to_include ALTER COLUMN weight SET DEFAULT 0',
+			],
+		],
 		//other
 	];
 }


### PR DESCRIPTION
The *_records_owned tables used to have a default weight of 0, but that was not transferred to *_records_to_include when they were dropped, so auto-inserts of owned records fail with an SQL error. This patch adds a default of 0 to allow them to succeed again.