### PR TITLE
Small Updates

### DIFF
--- a/code/web/interface/themes/responsive/MyAccount/deletedListEntry.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/deletedListEntry.tpl
@@ -16,10 +16,19 @@
 				<div class="col-xs-12">
 					<span class="result-index">{$resultIndex})</span>&nbsp;
 					{if !empty($deletedEntryTitle)}
-						<span class="result-title">{$deletedEntryTitle}</span>
-						<div>{translate text="This entry no longer exists in the catalog" isPublicFacing=true}</div>
+						{if $listEntrySource="Events"}
+							<span class="result-title">{$deletedEntryTitle}</span>
+							<div>{translate text="This event has passed" isPublicFacing=true}</div>
+						{else}
+							<span class="result-title">{$deletedEntryTitle}</span>
+							<div>{translate text="This entry no longer exists in the catalog" isPublicFacing=true}</div>
+						{/if}
 					{else}
-						<span class="result-title">{translate text="This entry no longer exists in the catalog" isPublicFacing=true}</span>
+						{if $listEntrySource="Events"}
+							<span class="result-title">{translate text="This event has passed" isPublicFacing=true}</span>
+						{else}
+							<span class="result-title">{translate text="This entry no longer exists in the catalog" isPublicFacing=true}</span>
+						{/if}
 					{/if}
 				</div>
 			</div>

--- a/code/web/interface/themes/responsive/MyAccount/myEventsList.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myEventsList.tpl
@@ -46,7 +46,7 @@
 									{/if}
 								</td>
 								<td class="myAccountCell">
-									<span class="btn btn-xs btn-warning" onclick="return AspenDiscovery.Account.deleteSavedEvent('{$event.sourceId}');">{translate text="Remove" isPublicFacing=true}</span>
+									<span class="btn btn-xs btn-warning" onclick="return AspenDiscovery.Account.deleteSavedEvent('{$event.sourceId}', {$page}, '{$eventsFilter|escape}');">{translate text="Remove" isPublicFacing=true}</span>
 								</td>
 							</tr>
 						{/foreach}

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -6998,12 +6998,14 @@ AspenDiscovery.Account = (function () {
 			return false;
 		},
 
-		deleteSavedEvent: function(id){
+		deleteSavedEvent: function(id, page, filter){
 			if (confirm("Are you sure you want to remove this event?")){
 				var url = Globals.path + '/MyAccount/AJAX?method=deleteSavedEvent&id=' + id ;
+
 				$.getJSON(url, function(data){
 					if (data.result === true){
-						AspenDiscovery.showMessage('Success', data.message, true);
+						AspenDiscovery.showMessage('Success', data.message, false);
+						AspenDiscovery.Account.loadEvents(page, filter);
 					}else{
 						AspenDiscovery.showMessage('Sorry', data.message);
 					}

--- a/code/web/interface/themes/responsive/js/aspen/account.js
+++ b/code/web/interface/themes/responsive/js/aspen/account.js
@@ -1694,12 +1694,14 @@ AspenDiscovery.Account = (function () {
 			return false;
 		},
 
-		deleteSavedEvent: function(id){
+		deleteSavedEvent: function(id, page, filter){
 			if (confirm("Are you sure you want to remove this event?")){
 				var url = Globals.path + '/MyAccount/AJAX?method=deleteSavedEvent&id=' + id ;
+
 				$.getJSON(url, function(data){
 					if (data.result === true){
-						AspenDiscovery.showMessage('Success', data.message, true);
+						AspenDiscovery.showMessage('Success', data.message, false);
+						AspenDiscovery.Account.loadEvents(page, filter);
 					}else{
 						AspenDiscovery.showMessage('Sorry', data.message);
 					}

--- a/code/web/services/API/ListAPI.php
+++ b/code/web/services/API/ListAPI.php
@@ -579,7 +579,14 @@ class ListAPI extends Action {
 				}
 			}
 
-			$totalRecords = $list->numValidListItems();
+			$isLida = $this->checkIfLiDA();
+
+			//if LiDA we don't want to include events list entries in the list count
+			if ($isLida){
+				$totalRecords = $list->numValidListItemsForLiDA();
+			}else {
+				$totalRecords = $list->numValidListItems();
+			}
 			$startRecord = ($page - 1) * $numTitlesToShow;
 			if ($startRecord < 0) {
 				$startRecord = 0;
@@ -593,35 +600,50 @@ class ListAPI extends Action {
 
 			$titles = $list->getListRecords($startRecord, $numTitlesToShow, false, 'summary', null, $sort);
 
-			$isLida = $this->checkIfLiDA();
-
 			foreach ($titles as $title) {
-				$imageUrl = "/bookcover.php?id=" . $title['id'];
-				$smallImageUrl = $imageUrl . "&size=small";
-				$imageUrl .= "&size=medium";
-
-				if ($isLida) {
+				if ($title['source'] != "Events" && $isLida){ //if LiDA don't look at events
 					$imageUrl = $configArray['Site']['url'] . "/bookcover.php?id=" . $title['id'];
 					$smallImageUrl = $imageUrl . "&size=small";
 					$imageUrl .= "&size=medium";
-				}
 
-				$listTitles[] = [
-					'id' => $title['id'],
-					'image' => $imageUrl,
-					'small_image' => $smallImageUrl,
-					'title' => $title['title'],
-					'author' => $title['author'],
-					'shortId' => $title['shortId'],
-					'recordType' => isset($title['recordType']) ? $title['recordType'] : $title['recordtype'],
-					'titleURL' => $title['titleURL'],
-					'description' => $title['description'],
-					'length' => $title['length'],
-					'publisher' => $title['publisher'],
-					'ratingData' => $title['ratingData'],
-					'format' => $title['format'],
-					'language' => $title['language'],
-				];
+					$listTitles[] = [
+						'id' => $title['id'],
+						'image' => $imageUrl,
+						'small_image' => $smallImageUrl,
+						'title' => $title['title'],
+						'author' => $title['author'],
+						'shortId' => $title['shortId'],
+						'recordType' => isset($title['recordType']) ? $title['recordType'] : $title['recordtype'],
+						'titleURL' => $title['titleURL'],
+						'description' => $title['description'],
+						'length' => $title['length'],
+						'publisher' => $title['publisher'],
+						'ratingData' => $title['ratingData'],
+						'format' => $title['format'],
+						'language' => $title['language'],
+					];
+				} else if (!$isLida) { //if not LiDA look at all the things
+					$imageUrl = "/bookcover.php?id=" . $title['id'];
+					$smallImageUrl = $imageUrl . "&size=small";
+					$imageUrl .= "&size=medium";
+
+					$listTitles[] = [
+						'id' => $title['id'],
+						'image' => $imageUrl,
+						'small_image' => $smallImageUrl,
+						'title' => $title['title'],
+						'author' => $title['author'],
+						'shortId' => $title['shortId'],
+						'recordType' => isset($title['recordType']) ? $title['recordType'] : $title['recordtype'],
+						'titleURL' => $title['titleURL'],
+						'description' => $title['description'],
+						'length' => $title['length'],
+						'publisher' => $title['publisher'],
+						'ratingData' => $title['ratingData'],
+						'format' => $title['format'],
+						'language' => $title['language'],
+					];
+				}
 			}
 			return [
 				'success' => true,

--- a/code/web/services/API/ListAPI.php
+++ b/code/web/services/API/ListAPI.php
@@ -598,11 +598,7 @@ class ListAPI extends Action {
 			];
 			$pager = new Pager($options);
 
-			if ($isLida){
-				$titles = $list->getListRecords($startRecord, $numTitlesToShow, false, 'summary', null, $sort, true);
-			}else{
-				$titles = $list->getListRecords($startRecord, $numTitlesToShow, false, 'summary', null, $sort);
-			}
+			$titles = $list->getListRecords($startRecord, $numTitlesToShow, false, 'summary', null, $sort, $isLida);
 
 			foreach ($titles as $title) {
 				if ($title['source'] != "Events" && $isLida){ //if LiDA don't look at events

--- a/code/web/services/API/ListAPI.php
+++ b/code/web/services/API/ListAPI.php
@@ -598,7 +598,11 @@ class ListAPI extends Action {
 			];
 			$pager = new Pager($options);
 
-			$titles = $list->getListRecords($startRecord, $numTitlesToShow, false, 'summary', null, $sort);
+			if ($isLida){
+				$titles = $list->getListRecords($startRecord, $numTitlesToShow, false, 'summary', null, $sort, true);
+			}else{
+				$titles = $list->getListRecords($startRecord, $numTitlesToShow, false, 'summary', null, $sort);
+			}
 
 			foreach ($titles as $title) {
 				if ($title['source'] != "Events" && $isLida){ //if LiDA don't look at events

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -3076,6 +3076,7 @@ class MyAccount_AJAX extends JSON_Action {
 		require_once ROOT_DIR . '/sys/Events/UserEventsEntry.php';
 
 		$page = $_REQUEST['page'] ?? 1;
+		$interface->assign('page', $page);
 		$pageSize = $_REQUEST['pageSize'] ?? 20;
 
 		$eventsFilter = $_REQUEST['eventsFilter'] ?? 'upcoming';

--- a/code/web/sys/UserLists/UserList.php
+++ b/code/web/sys/UserLists/UserList.php
@@ -106,6 +106,16 @@ class UserList extends DataObject {
 		return $listEntry->count();
 	}
 
+	function numValidListItemsForLiDA() {
+		require_once ROOT_DIR . '/sys/UserLists/UserListEntry.php';
+		$listEntry = new UserListEntry();
+		$listEntry->listId = $this->id;
+
+		if ($listEntry->source != "Events"){
+			return $listEntry->count();
+		}
+	}
+
 	function insert($createNow = true) {
 		if ($createNow) {
 			$this->created = time();
@@ -418,6 +428,7 @@ class UserList extends DataObject {
 					$interface->assign('recordIndex', $listPosition + 1);
 					$interface->assign('resultIndex', $listPosition + $start + 1);
 					$interface->assign('listEntryId', $listEntryInfo['listEntryId']);
+					$interface->assign('listEntrySource', $listEntryInfo['source']);
 					if (!empty($listEntryInfo['title'])) {
 						$interface->assign('deletedEntryTitle', $listEntryInfo['title']);
 					} else {
@@ -494,7 +505,7 @@ class UserList extends DataObject {
 					break;
 				}
 			}
-			if (!empty($current)) {
+			if (!empty($current) && ($currentId['source'] != "Events")) {
 				$results[$listPosition] = $current->getSummaryInformation();
 			}
 		}

--- a/code/web/sys/UserLists/UserList.php
+++ b/code/web/sys/UserLists/UserList.php
@@ -507,7 +507,7 @@ class UserList extends DataObject {
 					break;
 				}
 			}
-			if (!empty($current) && ($currentId['source'] != "Events")) {
+			if (!empty($current)) {
 				$results[$listPosition] = $current->getSummaryInformation();
 			}
 		}

--- a/code/web/sys/UserLists/UserList.php
+++ b/code/web/sys/UserLists/UserList.php
@@ -169,11 +169,14 @@ class UserList extends DataObject {
 	 * @param null $sort optional SQL for the query's ORDER BY clause
 	 * @return array      of list entries
 	 */
-	function getListEntries($sort = null) {
+	function getListEntries($sort = null, $forLiDA = false) {
 		global $interface;
 		require_once ROOT_DIR . '/sys/UserLists/UserListEntry.php';
 		$listEntry = new UserListEntry();
 		$listEntry->listId = $this->id;
+		if ($forLiDA){
+			$listEntry->whereAdd("source <> 'Events'");
+		}
 
 		$entryPosition = 0;
 		$zeroCount = 0;
@@ -375,12 +378,12 @@ class UserList extends DataObject {
 	 * @param string $sortName How records should be sorted, if no sort is provided, will use the default for the list
 	 * @return array     Array of HTML to display to the user
 	 */
-	public function getListRecords($start, $numItems, $allowEdit, $format, $citationFormat = null, $sortName = null): array {
+	public function getListRecords($start, $numItems, $allowEdit, $format, $citationFormat = null, $sortName = null, $forLiDA = false): array {
 		//Get all entries for the list
 		if ($sortName == null) {
 			$sortName = $this->defaultSort;
 		}
-		$listEntryInfo = $this->getListEntries($sortName);
+		$listEntryInfo = $this->getListEntries($sortName, $forLiDA);
 
 		//Trim to the number of records we want to return
 		if ($numItems > 0) {

--- a/code/web/sys/UserLists/UserList.php
+++ b/code/web/sys/UserLists/UserList.php
@@ -110,10 +110,9 @@ class UserList extends DataObject {
 		require_once ROOT_DIR . '/sys/UserLists/UserListEntry.php';
 		$listEntry = new UserListEntry();
 		$listEntry->listId = $this->id;
+		$listEntry->whereAdd("source <> 'Events'");
 
-		if ($listEntry->source != "Events"){
-			return $listEntry->count();
-		}
+		return $listEntry->count();
 	}
 
 	function insert($createNow = true) {


### PR DESCRIPTION
- When removing events from "Your Events", event is removed immediately (no page reload needed) 
- No more Events being pulled for lists in LiDA
- For past events in lists - display message "This event has passed" instead of "This entry no longer exists in the catalog"