### PR TITLE
Evergreen: adjustments to hold editing

### DIFF
--- a/code/web/Drivers/Evergreen.php
+++ b/code/web/Drivers/Evergreen.php
@@ -778,7 +778,6 @@ class Evergreen extends AbstractIlsDriver {
 						}
 						$curHold->cancelId = $holdInfo['id'];
 
-						//TODO: Validate if these are accurate
 						$curHold->locationUpdateable = true;
 						$curHold->cancelable = true;
 
@@ -800,7 +799,6 @@ class Evergreen extends AbstractIlsDriver {
 							}
 							$curHold->locationUpdateable = true;
 						} elseif (!empty($holdInfo['shelf_time'])) {
-							$curHold->cancelable = false;
 							$curHold->expirationDate = strtotime($holdInfo['shelf_expire_time']);
 							$curHold->status = "Ready to Pickup";
 							$curHold->available = true;


### PR DESCRIPTION
- Evergreen allows on-shelf holds to be canceled
- Whether or not the pickup location of an on-shelf hold can be changed depends on the user's permissions, so just try it and catch the error if it fails