### PR TITLE
Small Changes

### DIFF
--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -3343,7 +3343,7 @@ class User extends DataObject {
 			$sections['events'] = new AdminSection('Events');
 			$sections['events']->addAction(new AdminAction('Library Market - Calendar Settings', 'Define collections to be loaded into Aspen Discovery.', '/Events/LMLibraryCalendarSettings'), 'Administer LibraryMarket LibraryCalendar Settings');
 			$sections['events']->addAction(new AdminAction('Springshare - LibCal Settings', 'Define collections to be loaded into Aspen Discovery.', '/Events/SpringshareLibCalSettings'), 'Administer Springshare LibCal Settings');
-			$sections['events']->addAction(new AdminAction('Communico Settings', 'Define collections to be loaded into Aspen Discovery.', '/Events/CommunicoSettings'), 'Administer Communico Settings');
+			$sections['events']->addAction(new AdminAction('Communico - Attend Settings', 'Define collections to be loaded into Aspen Discovery.', '/Events/CommunicoSettings'), 'Administer Communico Settings');
 			$sections['events']->addAction(new AdminAction('Indexing Log', 'View the indexing log for Events.', '/Events/IndexingLog'), [
 				'View System Reports',
 				'View Indexing Logs',

--- a/code/web/sys/DBMaintenance/version_updates/23.04.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.04.00.php
@@ -287,7 +287,7 @@ function getUpdates23_04_00(): array {
 					title varchar(255) NOT NULL,
 					eventDate INT (11),
 					regRequired TINYINT DEFAULT 0,
-					location varchar(50),
+					location varchar(255),
 					dateAdded INT(11),
 					UNIQUE (sourceId)
 				)',
@@ -301,7 +301,14 @@ function getUpdates23_04_00(): array {
 				"ALTER TABLE user_events_entry CHANGE COLUMN sourceId sourceId VARCHAR(50) NOT NULL",
 			],
 		],
-
+		//user_events_entry_location_length
+		'user_events_entry_location_length' => [
+			'title' => 'User Events Entry location Length',
+			'description' => 'Increase allowed length for location in user event entries.',
+			'sql' => [
+				"ALTER TABLE user_events_entry CHANGE COLUMN location location VARCHAR(255) NOT NULL",
+			],
+		],
 		//user_events_entry_unique
 		'user_events_entry_unique' => [
 			'title' => 'Changes UNIQUE key for user_events_entry',


### PR DESCRIPTION
- Allow up to 255 characters for location when saving events
- Update Communico - Settings to Communico - Attend Settings (continuity for how we display Springshare and Library Market settings)