### PR TITLE
Browse Category Group Edit

### DIFF
--- a/code/web/release_notes/23.05.00.MD
+++ b/code/web/release_notes/23.05.00.MD
@@ -15,6 +15,8 @@
 // kirstien
 
 // kodi
+- If user has "Administer Library Browse Categories" permission, the user will not be able to edit browse categories not shared with everyone or their library when editing browse category groups
+- Fixed some display issues in browse category groups if the user did not have the "Administer All Browse Categories" permission
 
 // other
 

--- a/code/web/sys/Browse/BrowseCategoryGroupEntry.php
+++ b/code/web/sys/Browse/BrowseCategoryGroupEntry.php
@@ -103,7 +103,15 @@ class BrowseCategoryGroupEntry extends DataObject {
 	}
 
 	public function canActiveUserChangeSelection() {
-		return  UserAccount::userHasPermission('Administer All Browse Categories') ||  UserAccount::userHasPermission('Administer Library Browse Categories');
+		$library = Library::getPatronHomeLibrary(UserAccount::getActiveUserObj());
+		$libraryId = $library == null ? -1 : $library->libraryId;
+		$browseCatId = $this->getBrowseCategory()->libraryId;
+		if (($this->getBrowseCategory()->sharing == 'everyone') || (UserAccount::userHasPermission('Administer All Browse Categories'))) {
+			return true;
+		}else if ($browseCatId == $libraryId){
+			return UserAccount::userHasPermission('Administer Library Browse Categories');
+		}
+		return false;
 	}
 
 	public function canActiveUserDelete() {
@@ -111,11 +119,15 @@ class BrowseCategoryGroupEntry extends DataObject {
 	}
 
 	public function canActiveUserEdit() {
-		if ($this->getBrowseCategory()->sharing == 'everyone') {
-			return UserAccount::userHasPermission('Administer All Browse Categories');
+		$library = Library::getPatronHomeLibrary(UserAccount::getActiveUserObj());
+		$libraryId = $library == null ? -1 : $library->libraryId;
+		$browseCatId = $this->getBrowseCategory()->libraryId;
+		if (($this->getBrowseCategory()->sharing == 'everyone') || (UserAccount::userHasPermission('Administer All Browse Categories'))) {
+			return true;
+		}else if ($browseCatId == $libraryId){
+			return UserAccount::userHasPermission('Administer Library Browse Categories');
 		}
-		//Don't need to limit for the library since the user will need Administer Library Browse Categories to even view them.
-		return true;
+		return false;
 	}
 
 	public function toArray($includeRuntimeProperties = true, $encryptFields = false): array {


### PR DESCRIPTION
- Updated the Browse Category Groups page to check for the user's home library as well as their permissions so if they have "Administer Library Browse Categories" they will only be able to edit browse categories shared with everyone or with their library. They also cannot select a new browse category if it is not shared with everyone or their library, they can only delete it from the group. 
- Updated release notes