### PR TITLE
Events Changes

### DIFF
--- a/code/events_indexer/src/com/turning_leaf_technologies/events/CommunicoIndexer.java
+++ b/code/events_indexer/src/com/turning_leaf_technologies/events/CommunicoIndexer.java
@@ -3,11 +3,16 @@ package com.turning_leaf_technologies.events;
 import com.turning_leaf_technologies.strings.AspenStringUtils;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpEntity;
+import org.apache.http.NameValuePair;
 import org.apache.http.StatusLine;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.solr.client.solrj.SolrServerException;
@@ -420,7 +425,7 @@ class CommunicoIndexer {
 					apiEventsURL += "&startDate=" + firstOfMonth;
 					apiEventsURL += "&endDate=" + endOfMonth;
 					//Need to request the fields we want as many are "optional" and aren't returned unless asked for
-					apiEventsURL += "&fields=ages,searchTags,registration,eventImage,eventType,registrationOpens,registrationCloses,eventRegistrationUrl,thirdPartyRegistration,waitlist,maxAttendees,totalRegistrants,totalWaitlist,maxWaitlist,types";
+					apiEventsURL += "&fields=ages,searchTags,registration,eventImage,eventType,privateEvent,registrationOpens,registrationCloses,eventRegistrationUrl,thirdPartyRegistration,waitlist,maxAttendees,totalRegistrants,totalWaitlist,maxWaitlist,types";
 					HttpGet apiRequest = new HttpGet(apiEventsURL);
 					apiRequest.addHeader("Authorization", communicoAPITokenType + " " + communicoAPIToken);
 					try (CloseableHttpResponse response1 = httpclient.execute(apiRequest)) {
@@ -432,7 +437,10 @@ class CommunicoIndexer {
 							JSONObject data = response2.getJSONObject("data");
 							JSONArray events1 = data.getJSONArray("entries");
 							for (int i = 0; i < events1.length(); i++) {
-								events.put(events1.get(i));
+								JSONObject event = events1.getJSONObject(i);
+								if ((!event.getBoolean("privateEvent")) && (!event.getString("modified").equals("canceled"))){
+									events.put(events1.get(i));
+								}
 							}
 						}
 					} catch (Exception e) {

--- a/code/web/interface/themes/responsive/Communico/event.tpl
+++ b/code/web/interface/themes/responsive/Communico/event.tpl
@@ -65,7 +65,15 @@
 		</div>
 		<div class="col-sm-4" style="display:flex; justify-content:center;">
 			{if $recordDriver->inEvents()}
-				<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="In Your Events" isPublicFacing=true}</a>
+				{if $recordDriver->isRegistrationRequired()}
+					<div class="btn-group btn-group-vertical btn-block">
+						<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
+						<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Go To Your Events" isPublicFacing=true}</a>
+					</div>
+					<br>
+				{else}
+					<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="In Your Events" isPublicFacing=true}</a>
+				{/if}
 			{else}
 				{if $recordDriver->isRegistrationRequired()}
 					<a class="btn btn-primary"  onclick="return AspenDiscovery.Account.saveEventReg(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getExternalUrl()}');">

--- a/code/web/interface/themes/responsive/LibraryMarket/event.tpl
+++ b/code/web/interface/themes/responsive/LibraryMarket/event.tpl
@@ -45,7 +45,15 @@
 		</div>
 		<div class="col-sm-4" style="display:flex; justify-content:center;">
 			{if $recordDriver->inEvents()}
-				<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="In Your Events" isPublicFacing=true}</a>
+				{if $recordDriver->isRegistrationRequired()}
+					<div class="btn-group btn-group-vertical btn-block">
+						<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
+						<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Go To Your Events" isPublicFacing=true}</a>
+					</div>
+					<br>
+				{else}
+					<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="In Your Events" isPublicFacing=true}</a>
+				{/if}
 			{else}
 				{if $recordDriver->isRegistrationRequired()}
 					<a class="btn btn-primary"  onclick="return AspenDiscovery.Account.saveEventReg(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getExternalUrl()}');">

--- a/code/web/interface/themes/responsive/MyAccount/myEventsList.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myEventsList.tpl
@@ -12,6 +12,7 @@
 						<th>{translate text='Event Name' isPublicFacing=true}</th>
 						<th>{translate text='Location' isPublicFacing=true}</th>
 						<th>{translate text='Registration Required?' isPublicFacing=true}</th>
+						<th>{translate text='Registration Status' isPublicFacing=true}</th>
 						<th>&nbsp;</th>
 					</tr>
 					</thead>
@@ -43,6 +44,15 @@
 										<span>{translate text="Yes" isPublicFacing=true}</span>
 									{else}
 										<span>{translate text="No" isPublicFacing=true}</span>
+									{/if}
+								</td>
+								<td class="myAccountCell">
+									{if ($event.regRequired == 1)}
+										{if $event.externalLink != null}
+											<a href="{$event.externalLink}" class="btn btn-xs btn-warning" target="_blank"><i class="fas fa-external-link-alt"></i>{translate text=" Check Registration" isPublicFacing=true}</a>
+										{else}
+											<span>{translate text="Event Has Passed" isPublicFacing=true}</span>
+										{/if}
 									{/if}
 								</td>
 								<td class="myAccountCell">

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/communico_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/communico_result.tpl
@@ -49,12 +49,22 @@
 				{* Register Button *}
 				<div class="result-value col-tn-4">
 					{if $recordDriver->inEvents()}
-						<div class="btn-toolbar">
-							<div class="col-xs-12">
-								<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="In Your Events" isPublicFacing=true}</a>
+						{if $recordDriver->isRegistrationRequired()}
+							<div class="btn-toolbar">
+								<div class="btn-group btn-group-vertical btn-block">
+									<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
+									<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Go To Your Events" isPublicFacing=true}</a>
+								</div>
 							</div>
-						</div>
-						<br>
+							<br>
+						{else}
+							<div class="btn-toolbar">
+								<div class="col-xs-12">
+									<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="In Your Events" isPublicFacing=true}</a>
+								</div>
+							</div>
+							<br>
+						{/if}
 					{else}
 						{if $recordDriver->isRegistrationRequired()}
 							<div class="btn-toolbar">

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/library_calendar_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/library_calendar_result.tpl
@@ -49,12 +49,22 @@
 				{* Register Button *}
 				<div class="result-value col-tn-4">
 					{if $recordDriver->inEvents()}
-						<div class="btn-toolbar">
-							<div class="col-xs-12">
-								<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="In Your Events" isPublicFacing=true}</a>
+						{if $recordDriver->isRegistrationRequired()}
+							<div class="btn-toolbar">
+								<div class="btn-group btn-group-vertical btn-block">
+									<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
+									<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Go To Your Events" isPublicFacing=true}</a>
+								</div>
 							</div>
-						</div>
-						<br>
+							<br>
+						{else}
+							<div class="btn-toolbar">
+								<div class="col-xs-12">
+									<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="In Your Events" isPublicFacing=true}</a>
+								</div>
+							</div>
+							<br>
+						{/if}
 					{else}
 						{if $recordDriver->isRegistrationRequired()}
 							<div class="btn-toolbar">

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/springshare_libcal_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/springshare_libcal_result.tpl
@@ -49,16 +49,26 @@
 				{* Register Button *}
 				<div class="result-value col-tn-4">
 					{if $recordDriver->inEvents()}
-						<div class="btn-toolbar">
-							<div class="col-xs-12">
-								<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="In Your Events" isPublicFacing=true}</a>
+						{if $recordDriver->isRegistrationRequired()}
+							<div class="btn-toolbar">
+								<div class="btn-group btn-group-vertical btn-block">
+									<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
+									<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Go To Your Events" isPublicFacing=true}</a>
+								</div>
 							</div>
-						</div>
-						<br>
+							<br>
+						{else}
+							<div class="btn-toolbar">
+								<div class="btn-group btn-group-vertical btn-block">
+									<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="In Your Events" isPublicFacing=true}</a>
+								</div>
+							</div>
+							<br>
+						{/if}
 					{else}
 						{if $recordDriver->isRegistrationRequired()}
 							<div class="btn-toolbar">
-								<div class="col-xs-12">
+								<div class="btn-group btn-group-vertical btn-block">
 									<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.saveEventReg(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getExternalUrl()}');">
 										<i class="fas fa-external-link-alt"></i>{translate text=" Add to Your Events and Register" isPublicFacing=true}
 									</a>
@@ -67,7 +77,7 @@
 							<br>
 						{else}
 							<div class="btn-toolbar">
-								<div class="col-xs-12">
+								<div class="btn-group btn-group-vertical btn-block">
 									<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 								</div>
 							</div>

--- a/code/web/interface/themes/responsive/Springshare/event.tpl
+++ b/code/web/interface/themes/responsive/Springshare/event.tpl
@@ -59,7 +59,15 @@
 		</div>
 		<div class="col-sm-4" style="display:flex; justify-content:center;">
 			{if $recordDriver->inEvents()}
-				<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="In Your Events" isPublicFacing=true}</a>
+				{if $recordDriver->isRegistrationRequired()}
+					<div class="btn-group btn-group-vertical btn-block">
+						<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
+						<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Go To Your Events" isPublicFacing=true}</a>
+					</div>
+					<br>
+				{else}
+					<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="In Your Events" isPublicFacing=true}</a>
+				{/if}
 			{else}
 				{if $recordDriver->isRegistrationRequired()}
 					<a class="btn btn-primary"  onclick="return AspenDiscovery.Account.saveEventReg(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getExternalUrl()}');">

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -6977,7 +6977,7 @@ AspenDiscovery.Account = (function () {
 				// noinspection JSUnresolvedFunction
 				$.getJSON(url, params, function (data) {
 					if (data.success) {
-						AspenDiscovery.showMessage("Added Successfully", data.message, 2000, true); // auto-close after 2 seconds.
+						AspenDiscovery.showMessage(data.title, data.message, 2000, true); // auto-close after 2 seconds.
 					} else {
 						AspenDiscovery.showMessage("Error", data.message);
 					}
@@ -7002,7 +7002,7 @@ AspenDiscovery.Account = (function () {
 				// noinspection JSUnresolvedFunction
 				$.getJSON(url, params, function (data) {
 					if (data.success) {
-						AspenDiscovery.showMessage("Added Successfully", data.message, 2000, true); // auto-close after 2 seconds.
+						AspenDiscovery.showMessage(data.title, data.message, false, true); // do not auto-close if registrations required.
 						window.open(regLink, "_blank");
 					} else {
 						AspenDiscovery.showMessage("Error", data.message);

--- a/code/web/interface/themes/responsive/js/aspen/account.js
+++ b/code/web/interface/themes/responsive/js/aspen/account.js
@@ -1663,7 +1663,7 @@ AspenDiscovery.Account = (function () {
 				// noinspection JSUnresolvedFunction
 				$.getJSON(url, params, function (data) {
 					if (data.success) {
-						AspenDiscovery.showMessage("Added Successfully", data.message, 2000, true); // auto-close after 2 seconds.
+						AspenDiscovery.showMessage(data.title, data.message, 2000, true); // auto-close after 2 seconds.
 					} else {
 						AspenDiscovery.showMessage("Error", data.message);
 					}
@@ -1688,7 +1688,7 @@ AspenDiscovery.Account = (function () {
 				// noinspection JSUnresolvedFunction
 				$.getJSON(url, params, function (data) {
 					if (data.success) {
-						AspenDiscovery.showMessage("Added Successfully", data.message, 2000, true); // auto-close after 2 seconds.
+						AspenDiscovery.showMessage(data.title, data.message, false, true); // do not auto-close if registrations required.
 						window.open(regLink, "_blank");
 					} else {
 						AspenDiscovery.showMessage("Error", data.message);

--- a/code/web/release_notes/23.05.00.MD
+++ b/code/web/release_notes/23.05.00.MD
@@ -36,6 +36,9 @@
 - If user has "Administer Library Browse Categories" permission, the user will not be able to edit browse categories not shared with everyone or their library when editing browse category groups
 - Fixed some display issues in browse category groups if the user did not have the "Administer All Browse Categories" permission
 - "Add To Your Events" button will now display as "In Your Events" if user has event saved
+- If an event requires registration and is saved to a user's events, a "Check Registration" button will appear above a "Go To Your Events" button
+- If an event requires registration and is saved to a user's events, the event listing in their "Your Events" page will have a link to check their registration
+- When adding an event that requires registration, users will be notified that saving an event is not the same as registering and they are being redirected to the registration page (Tickets 113097, 112965)
 
 // other
 

--- a/code/web/release_notes/23.05.00.MD
+++ b/code/web/release_notes/23.05.00.MD
@@ -39,6 +39,7 @@
 - If an event requires registration and is saved to a user's events, a "Check Registration" button will appear above a "Go To Your Events" button
 - If an event requires registration and is saved to a user's events, the event listing in their "Your Events" page will have a link to check their registration
 - When adding an event that requires registration, users will be notified that saving an event is not the same as registering and they are being redirected to the registration page (Tickets 113097, 112965)
+- Private and canceled events will no longer be indexed for Communico
 
 // other
 

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -3117,6 +3117,7 @@ class MyAccount_AJAX extends JSON_Action {
 					'sourceId' => $entry->sourceId,
 					'title' => $entry->title,
 					'link' => $eventRecordDriver->getLinkUrl(),
+					'externalLink' => $eventRecordDriver->getExternalUrl(),
 					'location' => $entry->location,
 					'regRequired' => $entry->regRequired,
 					'eventDate' => $entry->eventDate,
@@ -3128,6 +3129,7 @@ class MyAccount_AJAX extends JSON_Action {
 				'sourceId' => $entry->sourceId,
 				'title' => $entry->title,
 				'link' => null,
+				'externalLink' => null,
 				'location' => $entry->location,
 				'regRequired' => $entry->regRequired,
 				'eventDate' => $entry->eventDate,
@@ -5524,6 +5526,7 @@ class MyAccount_AJAX extends JSON_Action {
 						}
 						$userEventsEntry->regRequired = $regRequired;
 						$userEventsEntry->location = $recordDriver->getBranch();
+						$externalUrl = $recordDriver->getExternalUrl();
 					}
 				} elseif (preg_match('`^libcal`', $userEventsEntry->sourceId)){
 					require_once ROOT_DIR . '/RecordDrivers/SpringshareLibCalEventRecordDriver.php';
@@ -5540,6 +5543,7 @@ class MyAccount_AJAX extends JSON_Action {
 						}
 						$userEventsEntry->regRequired = $regRequired;
 						$userEventsEntry->location = $recordDriver->getBranch();
+						$externalUrl = $recordDriver->getExternalUrl();
 					}
 				} elseif (preg_match('`^lc_`', $userEventsEntry->sourceId)){
 					require_once ROOT_DIR . '/RecordDrivers/LibraryCalendarEventRecordDriver.php';
@@ -5556,6 +5560,7 @@ class MyAccount_AJAX extends JSON_Action {
 						}
 						$userEventsEntry->regRequired = $regRequired;
 						$userEventsEntry->location = $recordDriver->getBranch();
+						$externalUrl = $recordDriver->getExternalUrl();
 					}
 				}
 				$existingEntry = false;
@@ -5572,10 +5577,22 @@ class MyAccount_AJAX extends JSON_Action {
 				}
 
 				$result['success'] = true;
-				$result['message'] = translate([
-					'text' => 'This event was saved to your events successfully.',
-					'isPublicFacing' => true,
+				$result['title'] = translate([
+					'text' => "Added Successfully",
 				]);
+				if ($regRequired){
+					$result['message'] = translate([
+						'text' => "This event was saved to your events successfully. Saving an event to your events is not the same as registering.</br></br> 
+						We are taking you to the library’s event management page where you will need to complete your registration. 
+						If you are not redirected to the event registration page, please follow <a href='$externalUrl'>this link.</a>",
+						'isPublicFacing' => true,
+					]);
+				}else{
+					$result['message'] = translate([
+						'text' => 'This event was saved to your events successfully.',
+						'isPublicFacing' => true,
+					]);
+				}
 			}
 		}
 


### PR DESCRIPTION
- Adds Check Registration buttons to various places in Aspen for all event integrations. These will appear in search results for events they have added to their events, as well as on the individual event pages.
- Also added a check registration column on the "Your Events" page if an event requires registration
- Made a couple modal titles translatable
- Updated modal for when a user adds an event to their events that requires registration. If they have pop-ups blocked there is a direct link they can follow in the modal.
- Don't index private and canceled events for Communico (Note: I did not include the newly built .java files because of the extra indexing things I'm working on)
- Updated Release Notes