### PR TITLE
User List API Results

### DIFF
--- a/code/web/interface/themes/responsive/Communico/event.tpl
+++ b/code/web/interface/themes/responsive/Communico/event.tpl
@@ -68,9 +68,9 @@
 				{if $recordDriver->isRegistrationRequired()}
 					<div class="btn-group btn-group-vertical btn-block">
 						{if $recordDriver->isRegisteredForEvent()}
-							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="You Are Registered" isPublicFacing=true}</a>
+							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="You Are Registered" isPublicFacing=true}</a>
 						{else}
-							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
+							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
 						{/if}
 						<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Go To Your Events" isPublicFacing=true}</a>
 					</div>

--- a/code/web/interface/themes/responsive/LibraryMarket/event.tpl
+++ b/code/web/interface/themes/responsive/LibraryMarket/event.tpl
@@ -47,7 +47,7 @@
 			{if $recordDriver->inEvents()}
 				{if $recordDriver->isRegistrationRequired()}
 					<div class="btn-group btn-group-vertical btn-block">
-						<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
+						<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
 						<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Go To Your Events" isPublicFacing=true}</a>
 					</div>
 					<br>

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/communico_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/communico_result.tpl
@@ -53,9 +53,9 @@
 							<div class="btn-toolbar">
 								<div class="btn-group btn-group-vertical btn-block">
 									{if $recordDriver->isRegisteredForEvent()}
-										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="You Are Registered" isPublicFacing=true}</a>
+										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="You Are Registered" isPublicFacing=true}</a>
 									{else}
-										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
+										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
 									{/if}
 									<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Go To Your Events" isPublicFacing=true}</a>
 								</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/library_calendar_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/library_calendar_result.tpl
@@ -52,7 +52,7 @@
 						{if $recordDriver->isRegistrationRequired()}
 							<div class="btn-toolbar">
 								<div class="btn-group btn-group-vertical btn-block">
-									<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
+									<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
 									<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Go To Your Events" isPublicFacing=true}</a>
 								</div>
 							</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/springshare_libcal_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/springshare_libcal_result.tpl
@@ -53,9 +53,9 @@
 							<div class="btn-toolbar">
 								<div class="btn-group btn-group-vertical btn-block">
 									{if $recordDriver->isRegisteredForEvent()}
-										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="You Are Registered" isPublicFacing=true}</a>
+										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="You Are Registered" isPublicFacing=true}</a>
 									{else}
-										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
+										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
 									{/if}
 										<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Go To Your Events" isPublicFacing=true}</a>
 								</div>

--- a/code/web/interface/themes/responsive/Springshare/event.tpl
+++ b/code/web/interface/themes/responsive/Springshare/event.tpl
@@ -62,9 +62,9 @@
 				{if $recordDriver->isRegistrationRequired()}
 					<div class="btn-group btn-group-vertical btn-block">
 						{if $recordDriver->isRegisteredForEvent()}
-							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="You Are Registered" isPublicFacing=true}</a>
+							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="You Are Registered" isPublicFacing=true}</a>
 						{else}
-							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
+							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Check Registration" isPublicFacing=true}</a>
 						{/if}
 						<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Go To Your Events" isPublicFacing=true}</a>
 					</div>

--- a/code/web/release_notes/23.05.01.MD
+++ b/code/web/release_notes/23.05.01.MD
@@ -3,7 +3,7 @@
 //kirstien
 
 //kodi
--Fixed an issue where user lists showed no results in LiDA
+- Fixed an issue where user lists showed no results in LiDA
 
 //other
 

--- a/code/web/release_notes/23.05.01.MD
+++ b/code/web/release_notes/23.05.01.MD
@@ -1,0 +1,13 @@
+//mark
+
+//kirstien
+
+//kodi
+-Fixed an issue where user lists showed no results in LiDA
+
+//other
+
+###This release includes code contributions from
+- ByWater Solutions
+
+_Thanks to all of our contributors!!_

--- a/code/web/release_notes/23.05.01.MD
+++ b/code/web/release_notes/23.05.01.MD
@@ -4,6 +4,7 @@
 
 //kodi
 - Fixed an issue where user lists showed no results in LiDA
+- "Check Registration" and "You Are Registered" buttons for events will now follow the same styling/color pattern used for the "On Hold for %1%" button
 
 //other
 

--- a/code/web/services/API/ListAPI.php
+++ b/code/web/services/API/ListAPI.php
@@ -601,7 +601,7 @@ class ListAPI extends Action {
 			$titles = $list->getListRecords($startRecord, $numTitlesToShow, false, 'summary', null, $sort, $isLida);
 
 			foreach ($titles as $title) {
-				if ($title['source'] != "Events" && $isLida){ //if LiDA don't look at events
+				if ($isLida){ //if LiDA don't look at events - filtered out in getListEntries()
 					$imageUrl = $configArray['Site']['url'] . "/bookcover.php?id=" . $title['id'];
 					$smallImageUrl = $imageUrl . "&size=small";
 					$imageUrl .= "&size=medium";


### PR DESCRIPTION
Remove check for $title['source'] != "Events" - this array did not exist and returned no results for all lists in LiDA. We filter out event results from lists for LiDA in getListEntries() in UserList.php
Updated release notes