### PR TITLE
Block Third Party Covers

### DIFF
--- a/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/staff-view.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/GroupedWork/staff-view.tpl
@@ -4,6 +4,11 @@
 	<button onclick="return AspenDiscovery.GroupedWork.getUploadCoverForm('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Upload Cover from Computer" isAdminFacing=true}</button>
 	<button onclick="return AspenDiscovery.GroupedWork.getUploadCoverFormByURL('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Upload Cover by URL" isAdminFacing=true}</button>
 	<button onclick="return AspenDiscovery.GroupedWork.clearUploadedCover('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Clear Uploaded Cover" isAdminFacing=true}</button>
+	{if $bookcoverInfo->disallowThirdPartyCover == 1}
+		<button onclick="return AspenDiscovery.GroupedWork.thirdPartyCoverToggle('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Allow Third Party Cover Image" isAdminFacing=true}</button>
+	{else}
+		<button onclick="return AspenDiscovery.GroupedWork.thirdPartyCoverToggle('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Hide Third Party Cover Image" isAdminFacing=true}</button>
+	{/if}
 {/if}
 <button onclick="return AspenDiscovery.GroupedWork.reloadEnrichment('{$recordDriver->getPermanentId()}')" class="btn btn-sm btn-default">{translate text="Reload Enrichment" isAdminFacing=true}</button>
 {if !empty($loggedIn) && in_array('Force Reindexing of Records', $userPermissions)}

--- a/code/web/interface/themes/responsive/RecordDrivers/Marc/staff.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Marc/staff.tpl
@@ -17,6 +17,11 @@
 					<button onclick="return AspenDiscovery.GroupedWork.getUploadCoverForm('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Upload Cover from Computer" isAdminFacing=true}</button>
 					<button onclick="return AspenDiscovery.GroupedWork.getUploadCoverFormByURL('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Upload Cover by URL" isAdminFacing=true}</button>
 					<button onclick="return AspenDiscovery.GroupedWork.clearUploadedCover('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Clear Uploaded Cover" isAdminFacing=true}</button>
+					{if $bookcoverInfo->disallowThirdPartyCover == 1}
+						<button onclick="return AspenDiscovery.GroupedWork.thirdPartyCoverToggle('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Allow Third Party Cover Image" isAdminFacing=true}</button>
+					{else}
+						<button onclick="return AspenDiscovery.GroupedWork.thirdPartyCoverToggle('{$recordDriver->getPermanentId()}', '{$bookcoverInfo->recordType}', '{$bookcoverInfo->recordId}')" class="btn btn-sm btn-default">{translate text="Hide Third Party Cover Image" isAdminFacing=true}</button>
+					{/if}
 				{/if}
 				{if !empty($loggedIn) && in_array('Upload PDFs', $userPermissions)}
 					<button onclick="return AspenDiscovery.Record.getUploadPDFForm('{$recordDriver->getId()}')" class="btn btn-sm btn-default">{translate text="Upload PDF Version" isAdminFacing=true}</button>

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -11251,6 +11251,14 @@ AspenDiscovery.GroupedWork = (function(){
 			return false;
 		},
 
+		thirdPartyCoverToggle: function (groupedWorkId, recordType, recordId){
+			var url = Globals.path + '/GroupedWork/' + groupedWorkId + '/AJAX?method=thirdPartyCoverToggle&recordType=' + recordType + '&recordId=' + recordId;
+			$.getJSON(url, function (data){
+				AspenDiscovery.showMessage("Success", data.message, true, true);
+			});
+			return false;
+		},
+
 		clearUploadedCover: function (groupedWorkId, recordType, recordId){
 			var url = Globals.path + '/GroupedWork/' + groupedWorkId + '/AJAX?method=clearUploadedCover&recordType=' + recordType + '&recordId=' + recordId;
 			$.getJSON(url, function (data){

--- a/code/web/interface/themes/responsive/js/aspen/grouped-work.js
+++ b/code/web/interface/themes/responsive/js/aspen/grouped-work.js
@@ -381,6 +381,14 @@ AspenDiscovery.GroupedWork = (function(){
 			return false;
 		},
 
+		thirdPartyCoverToggle: function (groupedWorkId, recordType, recordId){
+			var url = Globals.path + '/GroupedWork/' + groupedWorkId + '/AJAX?method=thirdPartyCoverToggle&recordType=' + recordType + '&recordId=' + recordId;
+			$.getJSON(url, function (data){
+				AspenDiscovery.showMessage("Success", data.message, true, true);
+			});
+			return false;
+		},
+
 		clearUploadedCover: function (groupedWorkId, recordType, recordId){
 			var url = Globals.path + '/GroupedWork/' + groupedWorkId + '/AJAX?method=clearUploadedCover&recordType=' + recordType + '&recordId=' + recordId;
 			$.getJSON(url, function (data){

--- a/code/web/services/GroupedWork/AJAX.php
+++ b/code/web/services/GroupedWork/AJAX.php
@@ -2353,6 +2353,81 @@ class GroupedWork_AJAX extends JSON_Action {
 	}
 
 	/** @noinspection PhpUnused */
+	function thirdPartyCoverToggle() {
+		require_once ROOT_DIR . '/RecordDrivers/GroupedWorkDriver.php';
+		$id = $_REQUEST['id'];
+		$recordDriver = new GroupedWorkDriver($id);
+
+		require_once ROOT_DIR . '/sys/Covers/BookCoverInfo.php';
+		$bookcoverInfo = new BookCoverInfo();
+		$bookcoverInfo->recordType = 'grouped_work';
+		$bookcoverInfo->recordId = $id;
+
+		if ($bookcoverInfo->find(true)) {
+			if ($bookcoverInfo->disallowThirdPartyCover == 0){
+				$bookcoverInfo->disallowThirdPartyCover = 1;
+				$result['message'] = translate([
+					'text' => 'Covers for this work will no longer be pulled from a third party.',
+					'isAdminFacing' => true,
+				]);
+			}else{
+				$bookcoverInfo->disallowThirdPartyCover = 0;
+				$result['message'] = translate([
+					'text' => 'Covers for this work will be pulled from a third party if one is available.',
+					'isAdminFacing' => true,
+				]);
+			}
+			$bookcoverInfo->thumbnailLoaded = 0;
+			$bookcoverInfo->mediumLoaded = 0;
+			$bookcoverInfo->largeLoaded = 0;
+			$bookcoverInfo->imageSource = '';
+			$bookcoverInfo->update();
+			$result['success'] = true;
+
+			$relatedRecords = $recordDriver->getRelatedRecords(true);
+			foreach ($relatedRecords as $record) {
+				$bookCoverInfo = new BookCoverInfo();
+				if (strpos($record->id, ':') > 0) {
+					[
+						$source,
+						$recordId,
+					] = explode(':', $record->id);
+					$bookCoverInfo->recordType = $source;
+					$bookCoverInfo->recordId = $recordId;
+				} else {
+					$bookCoverInfo->recordType = $record->source;
+					$bookCoverInfo->recordId = $record->id;
+				}
+
+				if ($bookCoverInfo->find(true)) {
+					//Force the image source to be determined again unless the user uploaded a cover.
+					if ($bookCoverInfo->disallowThirdPartyCover == 0){
+						$bookCoverInfo->disallowThirdPartyCover = 1;
+					}else{
+						$bookCoverInfo->disallowThirdPartyCover = 0;
+					}
+					if ($bookCoverInfo->imageSource != "upload") {
+						$bookCoverInfo->imageSource = '';
+					}
+					$bookCoverInfo->thumbnailLoaded = 0;
+					$bookCoverInfo->mediumLoaded = 0;
+					$bookCoverInfo->largeLoaded = 0;
+					$bookCoverInfo->update();
+				}
+			}
+		}else{
+			return [
+				'success' => false,
+				'message' => translate([
+					'text' => 'Unable to find book cover information for this record.',
+					'isAdminFacing' => true,
+				]),
+			];
+		}
+		return $result;
+	}
+
+	/** @noinspection PhpUnused */
 	function clearUploadedCover() {
 		require_once ROOT_DIR . '/sys/Covers/BookCoverInfo.php';
 		$bookcoverInfo = new BookCoverInfo();

--- a/code/web/sys/Covers/BookCoverInfo.php
+++ b/code/web/sys/Covers/BookCoverInfo.php
@@ -16,6 +16,7 @@ class BookCoverInfo extends DataObject {
 	public $mediumLoaded;
 	public $largeLoaded;
 	public $uploadedImage;
+	public $disallowThirdPartyCover;
 
 	public function getNumericColumnNames(): array {
 		return [
@@ -26,6 +27,7 @@ class BookCoverInfo extends DataObject {
 			'mediumLoaded',
 			'largeLoaded',
 			'uploadedImage',
+			'disallowThirdPartyCover',
 		];
 	}
 

--- a/code/web/sys/Covers/BookCoverProcessor.php
+++ b/code/web/sys/Covers/BookCoverProcessor.php
@@ -516,7 +516,7 @@ class BookCoverProcessor {
 
 	private function getCoverFromProvider() {
 		// Update to allow retrieval of covers based on upc
-		if (!is_null($this->isn) || !is_null($this->upc) || !is_null($this->issn)) {
+		if ((!is_null($this->isn) || !is_null($this->upc) || !is_null($this->issn)) && !$this->bookCoverInfo->disallowThirdPartyCover) {
 			$this->log("Looking for picture based on isbn and upc.", Logger::LOG_NOTICE);
 
 			//TODO: Allow these to be sorted

--- a/code/web/sys/DBMaintenance/version_updates/23.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.07.00.php
@@ -1,0 +1,24 @@
+<?php
+/** @noinspection PhpUnused */
+function getUpdates23_07_00(): array {
+	$curTime = time();
+	return [
+		/*'name' => [
+			'title' => '',
+			'description' => '',
+			'continueOnError' => false,
+			'sql' => [
+				''
+			]
+		], //sample*/
+
+		'add_disallow_third_party_covers' => [
+			'title' => 'Add option to disallow third party cover images for certain works',
+			'description' => 'Add option to disallow third party cover images for certain works',
+			'continueOnError' => true,
+			'sql' => [
+				'ALTER TABLE bookcover_info ADD COLUMN disallowThirdPartyCover TINYINT(1) DEFAULT 0',
+			],
+		], //add_disallow_third_party_covers
+	];
+}


### PR DESCRIPTION
Adds ability to block third party covers being fetched - blocking at either the grouped work or bib level will block the covers being fetched for all records in the grouped work