### PR TITLE
Custom Default Covers

### DIFF
--- a/code/web/release_notes/23.07.00.MD
+++ b/code/web/release_notes/23.07.00.MD
@@ -35,8 +35,8 @@
 
 <div markdown="1" class="settings">
 
-#### Revised Settings
-- New setting in Themes to add an image to be used for default covers 
+#### New Settings
+- New setting in Themes > Default Cover to add an image to be used for default covers 
 </div>
 
 // other

--- a/code/web/release_notes/23.07.00.MD
+++ b/code/web/release_notes/23.07.00.MD
@@ -30,6 +30,14 @@
 // kirstien
 
 // kodi
+###Default Cover Updates
+- Add ability to choose a default cover image for default covers generated for library catalog items (Tickets 113975, 100969)
+
+<div markdown="1" class="settings">
+
+#### Revised Settings
+- New setting in Themes to add an image to be used for default covers 
+</div>
 
 // other
 ### Other Updates

--- a/code/web/sys/Covers/DefaultCoverImageBuilder.php
+++ b/code/web/sys/Covers/DefaultCoverImageBuilder.php
@@ -136,11 +136,9 @@ class DefaultCoverImageBuilder {
 				$height = $artworkHeight;
 				$width = ($height * $originalWidth) / $originalHeight;
 			}
-			if ($imageInfo['mime'] == "image/jpeg" || $imageInfo['mime'] == "image/jpg") {
-				$uploadedImage = imagecreatefromjpeg($this->defaultCoverImage);
-			}else{
-				$uploadedImage = imagecreatefrompng($this->defaultCoverImage);
-			}
+
+			$uploadedImage = imagecreatefromstring(file_get_contents($this->defaultCoverImage));
+
 			$uploadedResized = imagescale($uploadedImage, $width, $height);
 			imagecopyresampled($imageCanvas, $uploadedResized, 0, $artworkStartY, 0, 0, $this->imageWidth, $artworkHeight, $width, $height);
 		}

--- a/code/web/sys/DBMaintenance/version_updates/23.07.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.07.00.php
@@ -35,6 +35,13 @@ function getUpdates23_07_00(): array {
 				'ALTER TABLE bookcover_info ADD COLUMN disallowThirdPartyCover TINYINT(1) DEFAULT 0',
 			],
 		], //add_disallow_third_party_covers
+		'theme_cover_default_image' => [
+			'title' => 'Theme - Set default image for cover images',
+			'description' => 'Update theme table to have default values for the default cover image',
+			'sql' => [
+				"ALTER TABLE themes ADD COLUMN defaultCover VARCHAR(100) default ''",
+			],
+		], //theme_cover_default_image
 
 		//other
 	];

--- a/code/web/sys/Theming/Theme.php
+++ b/code/web/sys/Theming/Theme.php
@@ -10,6 +10,7 @@ class Theme extends DataObject {
 	public $extendsTheme;
 	public $logoName;
 	public $favicon;
+	public $defaultCover;
 	public $logoApp;
 	public $fullWidth;
 
@@ -589,6 +590,16 @@ class Theme extends DataObject {
 				'thumbWidth' => 180,
 				'maxWidth' => 512,
 				'maxHeight' => 512,
+				'hideInLists' => true,
+			],
+			'defaultCover' => [
+				'property' => 'defaultCover',
+				'type' => 'image',
+				'label' => 'Background Image for Default Covers (280x280)',
+				'description' => 'A background image for default covers (.jpg or .png only)',
+				'required' => false,
+				'maxWidth' => 280,
+				'maxHeight' => 280,
 				'hideInLists' => true,
 			],
 			'coverStyle' => [


### PR DESCRIPTION
Adds ability to use a custom image for default covers

- Added column defaultCover to themes table
- Added ability to upload a default cover image in Theme settings 
- Updated DefaultCoverImageBuilder.php to use uploaded image if one exists 
- Updated release notes