### PR TITLE
EBSCOhost default covers

### DIFF
--- a/code/web/release_notes/23.07.00.MD
+++ b/code/web/release_notes/23.07.00.MD
@@ -32,7 +32,8 @@
 // kodi
 ###Default Cover Updates
 - Add ability to choose a default cover image for default covers generated for library catalog items (Tickets 113975, 100969)
-
+- Default cover images for EBSCOhost databases will use the logo uploaded in EBSCOhost Settings > edit search setting > edit database > logo
+- 
 <div markdown="1" class="settings">
 
 #### New Settings

--- a/code/web/release_notes/23.07.00.MD
+++ b/code/web/release_notes/23.07.00.MD
@@ -33,7 +33,7 @@
 ###Default Cover Updates
 - Add ability to choose a default cover image for default covers generated for library catalog items (Tickets 113975, 100969)
 - Default cover images for EBSCOhost databases will use the logo uploaded in EBSCOhost Settings > edit search setting > edit database > logo
-- 
+
 <div markdown="1" class="settings">
 
 #### New Settings

--- a/code/web/sys/Covers/BookCoverProcessor.php
+++ b/code/web/sys/Covers/BookCoverProcessor.php
@@ -1705,7 +1705,22 @@ class BookCoverProcessor {
 		if ($ebscohostRecordDriver->isValid()) {
 			$title = $ebscohostRecordDriver->getTitle();
 			$author = $ebscohostRecordDriver->getAuthor();
-			$coverBuilder->getCover($title, $author, $this->cacheFile);
+			$idParts = explode(':', $id);
+			$db = $idParts[0];
+
+			$ebscohostdb = new EBSCOhostDatabase();
+			$ebscohostdb->shortName = $db;
+			$ebscohostdb->find();
+			while ($ebscohostdb->fetch()) {
+				$image = $ebscohostdb->logo;
+			}
+			if (empty($image)) {
+				$coverBuilder->getCover($title, $author, $this->cacheFile);
+			} else {
+				$image = ROOT_DIR . '/files/original/' . $image;
+				$coverBuilder->getCover($title, $author, $this->cacheFile, $image);
+			}
+
 			return $this->processImageURL('default_ebscohost', $this->cacheFile, false);
 		} else {
 			return false;

--- a/code/web/sys/Covers/DefaultCoverImageBuilder.php
+++ b/code/web/sys/Covers/DefaultCoverImageBuilder.php
@@ -99,7 +99,7 @@ class DefaultCoverImageBuilder {
 		}
 	}
 
-	public function getCover($title, $author, $filename) {
+	public function getCover($title, $author, $filename, $image = null) {
 		$this->setForegroundAndBackgroundColors($title, $author);
 		//Create the background image
 		$imageCanvas = imagecreatetruecolor($this->imageWidth, $this->imageHeight);
@@ -119,9 +119,13 @@ class DefaultCoverImageBuilder {
 		$artworkHeight = $this->drawArtwork($imageCanvas, $backgroundColor, $foregroundColor, $title);
 		$this->drawText($imageCanvas, $title, $author, $artworkHeight);
 
-		if (!empty($this->defaultCoverImage)){
-			$artworkStartY = $this->imageHeight - $this->imageWidth;
-			$imageInfo = getimagesize($this->defaultCoverImage);
+		if (!empty($this->defaultCoverImage) || !empty($image)){
+			if (!empty($image)){
+				$imageInfo = getimagesize($image);
+			}else{
+				$imageInfo = getimagesize($this->defaultCoverImage);
+			}
+
 			$originalHeight = $imageInfo[0];
 			$originalWidth = $imageInfo[1];
 			$width = $originalWidth;
@@ -137,9 +141,15 @@ class DefaultCoverImageBuilder {
 				$width = ($height * $originalWidth) / $originalHeight;
 			}
 
-			$uploadedImage = imagecreatefromstring(file_get_contents($this->defaultCoverImage));
+			if (!empty($image)){
+				$uploadedImage = imagecreatefromstring(file_get_contents($image));
+			}else{
+				$uploadedImage = imagecreatefromstring(file_get_contents($this->defaultCoverImage));
+			}
 
 			$uploadedResized = imagescale($uploadedImage, $width, $height);
+			$artworkStartY = $this->imageHeight - $artworkHeight;
+
 			imagecopyresampled($imageCanvas, $uploadedResized, 0, $artworkStartY, 0, 0, $this->imageWidth, $artworkHeight, $width, $height);
 		}
 


### PR DESCRIPTION
- EBSCOhost default covers will use the logo uploaded for the individual databases if one exists - if there is not one, Aspen will use the default cover image uploaded in Themes (if one exists) 
- Updated release notes