### PR TITLE
Webpage Default Covers

### DIFF
--- a/code/web/RecordDrivers/WebsitePageRecordDriver.php
+++ b/code/web/RecordDrivers/WebsitePageRecordDriver.php
@@ -111,6 +111,10 @@ class WebsitePageRecordDriver extends IndexRecordDriver {
 		return $this->fields['id'];
 	}
 
+	public function getSettingId(){
+		return $this->fields['settingId'];
+	}
+
 	public function getLinkUrl($absolutePath = false) {
 		return $this->fields['source_url'];
 	}

--- a/code/web/release_notes/23.08.00.MD
+++ b/code/web/release_notes/23.08.00.MD
@@ -44,6 +44,13 @@
 - Updated the "Where is it?" button and modal title to be translated independently of one another. (Ticket 113412)
 
 //kodi - ByWater
+### Cover Updates
+- Added ability to set a default cover for each website indexing setting
+<div markdown="1" class="settings">
+
+#### New Settings
+- Website Indexing -> Settings -> Background Image for Default Covers
+</div>
 
 //other organizations
 

--- a/code/web/release_notes/23.08.00.MD
+++ b/code/web/release_notes/23.08.00.MD
@@ -46,10 +46,12 @@
 //kodi - ByWater
 ### Cover Updates
 - Added ability to set a default cover for each website indexing setting
+- Added ability to set a default cover for individual Open Archives collections
 <div markdown="1" class="settings">
 
 #### New Settings
 - Website Indexing -> Settings -> Background Image for Default Covers
+- Open Archives -> Collections -> Background Image for Default Covers
 </div>
 
 //other organizations

--- a/code/web/sys/Covers/BookCoverProcessor.php
+++ b/code/web/sys/Covers/BookCoverProcessor.php
@@ -1424,6 +1424,23 @@ class BookCoverProcessor {
 								}
 							}
 						}
+					}else if (!empty($sourceCollection->defaultCover)) {
+						//Build a cover based on the title of the page
+						require_once ROOT_DIR . '/sys/Covers/DefaultCoverImageBuilder.php';
+						$coverBuilder = new DefaultCoverImageBuilder();
+						require_once ROOT_DIR . '/RecordDrivers/OpenArchivesRecordDriver.php';
+
+						$OAIRecordDriver = new OpenArchivesRecordDriver($id);
+						if ($OAIRecordDriver->isValid()) {
+							$title = $OAIRecordDriver->getTitle();
+							$author = null;
+
+							$image = ROOT_DIR . '/files/original/' . $sourceCollection->defaultCover;
+							$coverBuilder->getCover($title, $author, $this->cacheFile, $image);
+							if ($this->processImageURL('open_archives',  $this->cacheFile, false)) {
+								return true;
+							}
+						}
 					}
 				}
 			}

--- a/code/web/sys/DBMaintenance/version_updates/23.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.08.00.php
@@ -56,6 +56,20 @@ function getUpdates23_08_00(): array {
 
 		//kodi - ByWater
 
+		'webpage_default_image' => [
+			'title' => 'Website Indexing - Set default image for cover images',
+			'description' => 'Update website_indexing_settings table to have default values for the default cover image',
+			'sql' => [
+				"ALTER TABLE website_indexing_settings ADD COLUMN defaultCover VARCHAR(100) default ''",
+			],
+		], //webpage_default_image
+		'OAI_default_image' => [
+			'title' => 'OAI Indexing - Set default image for cover images',
+			'description' => 'Update open_archives_collection table to have default values for the default cover image',
+			'sql' => [
+				"ALTER TABLE open_archives_collection ADD COLUMN defaultCover VARCHAR(100) default ''",
+			],
+		], //OAI_default_image
 
 		//other organizations
 

--- a/code/web/sys/OpenArchives/OpenArchivesCollection.php
+++ b/code/web/sys/OpenArchives/OpenArchivesCollection.php
@@ -11,6 +11,7 @@ class OpenArchivesCollection extends DataObject {
 	public $baseUrl;
 	public $setName;
 	public $subjects;
+	public $defaultCover;
 	public /** @noinspection PhpUnused */
 		$subjectFilters;
 	public $imageRegex;
@@ -48,6 +49,16 @@ class OpenArchivesCollection extends DataObject {
 				'label' => 'Base URL',
 				'description' => 'The url of the open archives site',
 				'size' => '255',
+			],
+			'defaultCover' => [
+				'property' => 'defaultCover',
+				'type' => 'image',
+				'label' => 'Background Image for Default Covers (280x280)',
+				'description' => 'A background image for default covers (.jpg or .png only)',
+				'required' => false,
+				'maxWidth' => 280,
+				'maxHeight' => 280,
+				'hideInLists' => true,
 			],
 			'setName' => [
 				'property' => 'setName',

--- a/code/web/sys/Recommend/TopFacets.php
+++ b/code/web/sys/Recommend/TopFacets.php
@@ -102,7 +102,7 @@ class TopFacets implements RecommendationInterface {
 								}else{
 									$facet['imageNameSelected'] = strtolower(str_replace(' ', '', $facet['value'])) . "_selected.png";
 								}
-							}elseif (strtolower($facet['value']) == "audiobooks" && !empty($appliedTheme->audioBooksImage)){
+							}elseif (strtolower($facet['value']) == "audio books" && !empty($appliedTheme->audioBooksImage)){
 								$facet['imageName'] = '/files/original/' . $appliedTheme->audioBooksImage;
 								if (!empty($appliedTheme->audioBooksImageSelected)){
 									$facet['imageNameSelected'] = '/files/original/' . $appliedTheme->audioBooksImageSelected;

--- a/code/web/sys/WebsiteIndexing/WebsiteIndexSetting.php
+++ b/code/web/sys/WebsiteIndexing/WebsiteIndexSetting.php
@@ -8,6 +8,7 @@ class WebsiteIndexSetting extends DataObject {
 	public $name;
 	public $searchCategory;
 	public $siteUrl;
+	public $defaultCover;
 	public /** @noinspection PhpUnused */
 		$pageTitleExpression;
 	public /** @noinspection PhpUnused */
@@ -69,6 +70,16 @@ class WebsiteIndexSetting extends DataObject {
 				'description' => 'The URL to the page in the Website to start indexing from or a sitemap to index based on. Sitemap must have a .xml extension.',
 				'maxLength' => 255,
 				'required' => true,
+			],
+			'defaultCover' => [
+				'property' => 'defaultCover',
+				'type' => 'image',
+				'label' => 'Background Image for Default Covers (280x280)',
+				'description' => 'A background image for default covers (.jpg or .png only)',
+				'required' => false,
+				'maxWidth' => 280,
+				'maxHeight' => 280,
+				'hideInLists' => true,
 			],
 			'pageTitleExpression' => [
 				'property' => 'pageTitleExpression',


### PR DESCRIPTION
Set default covers for each instance of website indexing settings 
- WebsitePageRecordDriver.php - Added function to get settingId 
- WebPageCoverBuilder.php - if webpage belongs to an indexing setting that has a set default cover, that image will be used instead of the globe 
- WebsiteIndexSetting.php - Added area to upload default cover image 
- Updated 23.08.00.php and release notes