### PR TITLE
Event Registration Updates 

### DIFF
--- a/code/web/RecordDrivers/CommunicoEventRecordDriver.php
+++ b/code/web/RecordDrivers/CommunicoEventRecordDriver.php
@@ -171,6 +171,19 @@ class CommunicoEventRecordDriver extends IndexRecordDriver {
 		}
 	}
 
+	public function getRegistrationModalBody() {
+		require_once ROOT_DIR . '/sys/Events/CommunicoSetting.php';
+		$eventSettings = new CommunicoSetting;
+		$eventSettings->id = $this->getSource();
+		if ($eventSettings->find(true)){
+			if ($eventSettings->registrationModalBody){
+				return $eventSettings->registrationModalBody;
+			} else {
+				return null;
+			}
+		}
+	}
+
 	public function getExternalUrl($absolutePath = false) {
 		return $this->fields['url'];
 	}

--- a/code/web/RecordDrivers/LibraryCalendarEventRecordDriver.php
+++ b/code/web/RecordDrivers/LibraryCalendarEventRecordDriver.php
@@ -167,6 +167,19 @@ class LibraryCalendarEventRecordDriver extends IndexRecordDriver {
 		}
 	}
 
+	public function getRegistrationModalBody() {
+		require_once ROOT_DIR . '/sys/Events/LMLibraryCalendarSetting.php';
+		$eventSettings = new LMLibraryCalendarSetting;
+		$eventSettings->id = $this->getSource();
+		if ($eventSettings->find(true)){
+			if ($eventSettings->registrationModalBody){
+				return $eventSettings->registrationModalBody;
+			} else {
+				return null;
+			}
+		}
+	}
+
 	public function getExternalUrl($absolutePath = false) {
 		return $this->fields['url'];
 	}

--- a/code/web/RecordDrivers/SpringshareLibCalEventRecordDriver.php
+++ b/code/web/RecordDrivers/SpringshareLibCalEventRecordDriver.php
@@ -190,6 +190,19 @@ class SpringshareLibCalEventRecordDriver extends IndexRecordDriver {
 		}
 	}
 
+	public function getRegistrationModalBody() {
+		require_once ROOT_DIR . '/sys/Events/SpringshareLibCalSetting.php';
+		$eventSettings = new SpringshareLibCalSetting;
+		$eventSettings->id = $this->getSource();
+		if ($eventSettings->find(true)){
+			if ($eventSettings->registrationModalBody){
+				return $eventSettings->registrationModalBody;
+			} else {
+				return null;
+			}
+		}
+	}
+
 	private function getType() {
 		return $this->fields['type'];
 	}

--- a/code/web/interface/themes/responsive/Communico/event.tpl
+++ b/code/web/interface/themes/responsive/Communico/event.tpl
@@ -77,13 +77,13 @@
 				{if $recordDriver->isRegistrationRequired()}
 					<div class="btn-group btn-group-vertical btn-block">
 						{if $recordDriver->isRegisteredForEvent()}
-							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="You Are Registered" isPublicFacing=true}</a>
+							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="You Are Registered" isPublicFacing=true}</a>
 						{else}
 							{if !empty($recordDriver->getRegistrationModalBody())}
 								<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');" style="width:70%"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
 								</a>
 							{else}
-								<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+								<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
 							{/if}
 						{/if}
 						<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:70%">{translate text="Go To Your Events" isPublicFacing=true}</a>
@@ -99,7 +99,7 @@
 							<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');" style="width:70%"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
 							</a>
 						{else}
-							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
 						{/if}
 						<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 					</div>

--- a/code/web/interface/themes/responsive/Communico/event.tpl
+++ b/code/web/interface/themes/responsive/Communico/event.tpl
@@ -79,7 +79,12 @@
 						{if $recordDriver->isRegisteredForEvent()}
 							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="You Are Registered" isPublicFacing=true}</a>
 						{else}
-							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Check Registration" isPublicFacing=true}</a>
+							{if !empty($recordDriver->getRegistrationModalBody())}
+								<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');" style="width:70%"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
+								</a>
+							{else}
+								<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+							{/if}
 						{/if}
 						<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:70%">{translate text="Go To Your Events" isPublicFacing=true}</a>
 					</div>
@@ -90,13 +95,14 @@
 			{else}
 				{if $recordDriver->isRegistrationRequired()}
 					<div class="btn-group btn-group-vertical btn-block">
-						<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
-						<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');" class="btn btn-sm btn-action btn-wrap" style="width:70%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+						{if !empty($recordDriver->getRegistrationModalBody())}
+							<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');" style="width:70%"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
+							</a>
+						{else}
+							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+						{/if}
+						<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 					</div>
-					{*<a class="btn btn-sm btn-action btn-wrap" style="width:70%"  onclick="return AspenDiscovery.Account.saveEventReg(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getExternalUrl()}');">
-						<i class="fas fa-external-link-alt"></i>
-						{translate text=" Add to Your Events and Register" isPublicFacing=true}
-					</a>*}
 				{else}
 					<a class="btn btn-sm btn-action btn-wrap" style="width:70%" onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');">{translate text="Add to Your Events" isPublicFacing=true}</a>
 				{/if}

--- a/code/web/interface/themes/responsive/GroupedWork/singleVariationManifestion.tpl
+++ b/code/web/interface/themes/responsive/GroupedWork/singleVariationManifestion.tpl
@@ -2,7 +2,7 @@
 <div class="col-xs-12">
 	<div class="row">
 		<div class="col-tn-4 col-xs-4{if empty($viewingCombinedResults)} col-md-3{/if} manifestation-format">
-			<a class="btn btn-xs btn-primary btn-wrap" href="{$relatedManifestation->getUrl()}" {if $relatedManifestation->getNumRelatedRecords() > 1}onclick="return AspenDiscovery.ResultsList.showRelatedManifestations('{$workId|escapeCSS},{$relatedManifestation->format|escapeCSS}','{$relatedManifestation->getFirstVariation()->databaseId|escapeCSS}');" aria-label="View Manifestations for {translate text=$relatedManifestation->format inAttribute=true isPublicFacing=true}"{else} aria-label="View {translate text=$relatedManifestation->format inAttribute=true}"{/if}>
+			<a class="btn btn-xs btn-primary btn-wrap" href="{$relatedManifestation->getUrl()}" {if $relatedManifestation->getNumRelatedRecords() > 1}onclick="return AspenDiscovery.ResultsList.showRelatedManifestations('{$workId|escapeCSS}','{$relatedManifestation->format|escapeCSS}','{$relatedManifestation->getFirstVariation()->databaseId|escapeCSS}');" aria-label="View Manifestations for {translate text=$relatedManifestation->format inAttribute=true isPublicFacing=true}"{else} aria-label="View {translate text=$relatedManifestation->format inAttribute=true}"{/if}>
 				{translate text=$relatedManifestation->format isPublicFacing=true}
 			</a>
 			<br>

--- a/code/web/interface/themes/responsive/LibraryMarket/event.tpl
+++ b/code/web/interface/themes/responsive/LibraryMarket/event.tpl
@@ -60,7 +60,12 @@
 				{if $recordDriver->inEvents()}
 					{if $recordDriver->isRegistrationRequired()}
 						<div class="btn btn-sm btn-action btn-wrap" style="width:70%">
-							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Check Registration" isPublicFacing=true}</a>
+							{if !empty($recordDriver->getRegistrationModalBody())}
+								<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');" style="width:70%"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
+								</a>
+							{else}
+								<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+							{/if}
 							<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap">{translate text="Go To Your Events" isPublicFacing=true}</a>
 						</div>
 						<br>
@@ -70,13 +75,14 @@
 				{else}
 					{if $recordDriver->isRegistrationRequired()}
 						<div class="btn-group btn-group-vertical btn-block">
-							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+							{if !empty($recordDriver->getRegistrationModalBody())}
+								<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');" style="width:70%"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
+								</a>
+							{else}
+								<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+							{/if}
 							<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');" class="btn btn-sm btn-action btn-wrap" style="width:70%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 						</div>
-						{*<a class="btn btn-sm btn-action btn-wrap" style="width:70%"  onclick="return AspenDiscovery.Account.saveEventReg(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getExternalUrl()}');">
-							<i class="fas fa-external-link-alt"></i>
-							{translate text=" Add to Your Events and Register" isPublicFacing=true}
-						</a>*}
 					{else}
 						<a class="btn btn-sm btn-action btn-wrap" style="width:70%" onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');">{translate text="Add to Your Events" isPublicFacing=true}</a>
 					{/if}

--- a/code/web/interface/themes/responsive/LibraryMarket/event.tpl
+++ b/code/web/interface/themes/responsive/LibraryMarket/event.tpl
@@ -64,7 +64,7 @@
 								<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');" style="width:70%"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
 								</a>
 							{else}
-								<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+								<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
 							{/if}
 							<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap">{translate text="Go To Your Events" isPublicFacing=true}</a>
 						</div>
@@ -79,7 +79,7 @@
 								<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');" style="width:70%"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
 								</a>
 							{else}
-								<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+								<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
 							{/if}
 							<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');" class="btn btn-sm btn-action btn-wrap" style="width:70%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 						</div>

--- a/code/web/interface/themes/responsive/MyAccount/myEventsList.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myEventsList.tpl
@@ -11,7 +11,6 @@
 						<th>{translate text='Start Time' isPublicFacing=true}</th>
 						<th>{translate text='Event Name' isPublicFacing=true}</th>
 						<th>{translate text='Location' isPublicFacing=true}</th>
-						<th>{translate text='Registration Required?' isPublicFacing=true}</th>
 						<th>{translate text='Registration Status' isPublicFacing=true}</th>
 						<th>&nbsp;</th>
 					</tr>
@@ -41,15 +40,13 @@
 								</td>
 								<td class="myAccountCell">
 									{if ($event.regRequired == 1)}
-										<span>{translate text="Yes" isPublicFacing=true}</span>
-									{else}
-										<span>{translate text="No" isPublicFacing=true}</span>
-									{/if}
-								</td>
-								<td class="myAccountCell">
-									{if ($event.regRequired == 1)}
 										{if $event.externalLink != null && !($event.isRegistered)}
-											<a href="{$event.externalLink}" class="btn btn-xs btn-action" target="_blank"><i class="fas fa-external-link-alt"></i>&nbsp{translate text=" Check Registration" isPublicFacing=true}</a>
+											{if !empty($event.regModalBody)}
+												<a class="btn btn-xs btn-action" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$event.id}', '{($event.regModalBody)}', '{$event.externalLink}');"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Check Registration" isPublicFacing=true}
+												</a>
+											{else}
+												<a href="{$event.externalLink}" class="btn btn-xs btn-action" target="_blank"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Check Registration" isPublicFacing=true}</a>
+											{/if}
 										{elseif $event.isRegistered}
 											<a href="{$event.externalLink}" class="btn btn-xs btn-action" target="_blank"><i class="fas fa-external-link-alt"></i>&nbsp{translate text=" You Are Registered" isPublicFacing=true}</a>
 										{else}

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/communico_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/communico_result.tpl
@@ -53,13 +53,13 @@
 							<div class="btn-toolbar">
 								<div class="btn-group btn-group-vertical btn-block">
 									{if $recordDriver->isRegisteredForEvent()}
-										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="You Are Registered" isPublicFacing=true}</a>
+										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="You Are Registered" isPublicFacing=true}</a>
 									{else}
 										{if !empty($recordDriver->getRegistrationModalBody())}
 											<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
 											</a>
 										{else}
-											<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+											<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
 										{/if}
 									{/if}
 									<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Go To Your Events" isPublicFacing=true}</a>
@@ -82,7 +82,7 @@
 										<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
 										</a>
 									{else}
-										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
 									{/if}
 									<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 								</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/communico_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/communico_result.tpl
@@ -55,7 +55,12 @@
 									{if $recordDriver->isRegisteredForEvent()}
 										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="You Are Registered" isPublicFacing=true}</a>
 									{else}
-										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Check Registration" isPublicFacing=true}</a>
+										{if !empty($recordDriver->getRegistrationModalBody())}
+											<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');" style="width:100%"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
+											</a>
+										{else}
+											<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+										{/if}
 									{/if}
 									<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Go To Your Events" isPublicFacing=true}</a>
 								</div>
@@ -73,14 +78,14 @@
 						{if $recordDriver->isRegistrationRequired()}
 							<div class="btn-toolbar">
 								<div class="btn-group btn-group-vertical btn-block">
-									<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+									{if !empty($recordDriver->getRegistrationModalBody())}
+										<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
+										</a>
+									{else}
+										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+									{/if}
 									<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 								</div>
-								{*<div class="col-xs-12">
-									<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.saveEventReg(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getExternalUrl()}');">
-										<i class="fas fa-external-link-alt"></i>{translate text=" Add to Your Events and Register" isPublicFacing=true}
-									</a>
-								</div>*}
 							</div>
 							<br>
 						{else}

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/library_calendar_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/library_calendar_result.tpl
@@ -69,7 +69,12 @@
 						{if $recordDriver->isRegistrationRequired()}
 							<div class="btn-toolbar">
 								<div class="btn-group btn-group-vertical btn-block">
-									<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+									{if !empty($recordDriver->getRegistrationModalBody())}
+										<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
+										</a>
+									{else}
+										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+									{/if}
 									<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 								</div>
 								{*<div class="col-xs-12">

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/library_calendar_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/library_calendar_result.tpl
@@ -52,7 +52,7 @@
 						{if $recordDriver->isRegistrationRequired()}
 							<div class="btn-toolbar">
 								<div class="btn-group btn-group-vertical btn-block">
-									<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Check Registration" isPublicFacing=true}</a>
+									<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Check Registration" isPublicFacing=true}</a>
 									<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Go To Your Events" isPublicFacing=true}</a>
 								</div>
 							</div>
@@ -73,7 +73,7 @@
 										<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
 										</a>
 									{else}
-										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
 									{/if}
 									<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 								</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/springshare_libcal_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/springshare_libcal_result.tpl
@@ -53,9 +53,9 @@
 							<div class="btn-toolbar">
 								<div class="btn-group btn-group-vertical btn-block">
 									{if $recordDriver->isRegisteredForEvent()}
-										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="You Are Registered" isPublicFacing=true}</a>
+										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="You Are Registered" isPublicFacing=true}</a>
 									{else}
-										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Check Registration" isPublicFacing=true}</a>
+										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Check Registration" isPublicFacing=true}</a>
 									{/if}
 										<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Go To Your Events" isPublicFacing=true}</a>
 								</div>
@@ -77,7 +77,7 @@
 										<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
 										</a>
 									{else}
-										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
 									{/if}
 									<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 								</div>

--- a/code/web/interface/themes/responsive/RecordDrivers/Events/springshare_libcal_result.tpl
+++ b/code/web/interface/themes/responsive/RecordDrivers/Events/springshare_libcal_result.tpl
@@ -73,14 +73,14 @@
 						{if $recordDriver->isRegistrationRequired()}
 							<div class="btn-toolbar">
 								<div class="btn-group btn-group-vertical btn-block">
-									<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+									{if !empty($recordDriver->getRegistrationModalBody())}
+										<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
+										</a>
+									{else}
+										<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+									{/if}
 									<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 								</div>
-								{*<div class="btn-group btn-group-vertical btn-block">
-									<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.saveEventReg(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getExternalUrl()}');">
-										<i class="fas fa-external-link-alt"></i>{translate text=" Add to Your Events and Register" isPublicFacing=true}
-									</a>
-								</div>*}
 							</div>
 							<br>
 						{else}

--- a/code/web/interface/themes/responsive/Springshare/event.tpl
+++ b/code/web/interface/themes/responsive/Springshare/event.tpl
@@ -77,7 +77,12 @@
 						{if $recordDriver->isRegisteredForEvent()}
 							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="You Are Registered" isPublicFacing=true}</a>
 						{else}
-							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Check Registration" isPublicFacing=true}</a>
+							{if !empty($recordDriver->getRegistrationModalBody())}
+								<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');" style="width:70%"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
+								</a>
+							{else}
+								<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+							{/if}
 						{/if}
 						<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:70%">{translate text="Go To Your Events" isPublicFacing=true}</a>
 					</div>
@@ -88,13 +93,14 @@
 			{else}
 				{if $recordDriver->isRegistrationRequired()}
 					<div class="btn-group btn-group-vertical btn-block">
-						<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
-						<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');" class="btn btn-sm btn-action btn-wrap" style="width:70%">{translate text="Add to Your Events" isPublicFacing=true}</a>
+						{if !empty($recordDriver->getRegistrationModalBody())}
+							<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');" style="width:70%"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
+							</a>
+						{else}
+							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+						{/if}
+						<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 					</div>
-					{*<a class="btn btn-sm btn-action btn-wrap" style="width:70%" onclick="return AspenDiscovery.Account.saveEventReg(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getExternalUrl()}');">
-						<i class="fas fa-external-link-alt"></i>
-						{translate text=" Add to Your Events and Register" isPublicFacing=true}
-					</a>*}
 				{else}
 					<a class="btn btn-sm btn-action btn-wrap" style="width:70%" onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');">{translate text="Add to Your Events" isPublicFacing=true}</a>
 				{/if}

--- a/code/web/interface/themes/responsive/Springshare/event.tpl
+++ b/code/web/interface/themes/responsive/Springshare/event.tpl
@@ -75,13 +75,13 @@
 				{if $recordDriver->isRegistrationRequired()}
 					<div class="btn-group btn-group-vertical btn-block">
 						{if $recordDriver->isRegisteredForEvent()}
-							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="You Are Registered" isPublicFacing=true}</a>
+							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="You Are Registered" isPublicFacing=true}</a>
 						{else}
 							{if !empty($recordDriver->getRegistrationModalBody())}
 								<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');" style="width:70%"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
 								</a>
 							{else}
-								<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+								<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:70%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
 							{/if}
 						{/if}
 						<a href="/MyAccount/MyEvents?page=1&eventsFilter=upcoming" class="btn btn-sm btn-action btn-wrap" style="width:70%">{translate text="Go To Your Events" isPublicFacing=true}</a>
@@ -97,7 +97,7 @@
 							<a class="btn btn-sm btn-action btn-wrap" onclick="return AspenDiscovery.Account.regInfoModal(this, 'Events', '{$recordDriver->getUniqueID()|escape}', '{$recordDriver->getRegistrationModalBody()}', '{$recordDriver->getExternalUrl()}');" style="width:70%"><i class="fas fa-external-link-alt"></i>{translate text="Registration Information" isPublicFacing=true}
 							</a>
 						{else}
-							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-info btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
+							<a href="{$recordDriver->getExternalUrl()}" class="btn btn-sm btn-action btn-wrap" target="_blank" style="width:100%"><i class="fas fa-external-link-alt"></i>&nbsp{translate text="Registration Information" isPublicFacing=true}</a>
 						{/if}
 						<a onclick="return AspenDiscovery.Account.saveEvent(this, 'Events', '{$recordDriver->getUniqueID()|escape}');" class="btn btn-sm btn-action btn-wrap" style="width:100%">{translate text="Add to Your Events" isPublicFacing=true}</a>
 					</div>

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -7081,27 +7081,27 @@ AspenDiscovery.Account = (function () {
 			return false;
 		},
 
-		saveEventReg: function (trigger, source, id, regLink) {
+		regInfoModal: function (trigger, source, id, body, regLink) {
 			if (Globals.loggedIn) {
 				var url = Globals.path + "/MyAccount/AJAX";
 				var params = {
-					'method': 'saveEvent',
+					'method': 'eventRegistrationModal',
 					sourceId: id,
 					source: source,
-					regLink: regLink
+					body: body,
+					regLink: regLink,
 				};
 				// noinspection JSUnresolvedFunction
 				$.getJSON(url, params, function (data) {
 					if (data.success) {
-						AspenDiscovery.showMessage(data.title, data.message, false, true); // do not auto-close if registrations required.
-						window.open(regLink, "_blank");
+						AspenDiscovery.showMessageWithButtons(data.title, body, data.buttons, false);
 					} else {
 						AspenDiscovery.showMessage("Error", data.message);
 					}
 				}).fail(AspenDiscovery.ajaxFail);
 			}else {
 				AspenDiscovery.Account.ajaxLogin(null, function () {
-					return AspenDiscovery.Account.saveEventReg(trigger, source, id);
+					return AspenDiscovery.Account.regInfoModal(trigger, source, id);
 				}, false);
 			}
 			return false;

--- a/code/web/interface/themes/responsive/js/aspen/account.js
+++ b/code/web/interface/themes/responsive/js/aspen/account.js
@@ -1757,27 +1757,27 @@ AspenDiscovery.Account = (function () {
 			return false;
 		},
 
-		saveEventReg: function (trigger, source, id, regLink) {
+		regInfoModal: function (trigger, source, id, body, regLink) {
 			if (Globals.loggedIn) {
 				var url = Globals.path + "/MyAccount/AJAX";
 				var params = {
-					'method': 'saveEvent',
+					'method': 'eventRegistrationModal',
 					sourceId: id,
 					source: source,
-					regLink: regLink
+					body: body,
+					regLink: regLink,
 				};
 				// noinspection JSUnresolvedFunction
 				$.getJSON(url, params, function (data) {
 					if (data.success) {
-						AspenDiscovery.showMessage(data.title, data.message, false, true); // do not auto-close if registrations required.
-						window.open(regLink, "_blank");
+						AspenDiscovery.showMessageWithButtons(data.title, body, data.buttons, false);
 					} else {
 						AspenDiscovery.showMessage("Error", data.message);
 					}
 				}).fail(AspenDiscovery.ajaxFail);
 			}else {
 				AspenDiscovery.Account.ajaxLogin(null, function () {
-					return AspenDiscovery.Account.saveEventReg(trigger, source, id);
+					return AspenDiscovery.Account.regInfoModal(trigger, source, id);
 				}, false);
 			}
 			return false;

--- a/code/web/release_notes/23.08.00.MD
+++ b/code/web/release_notes/23.08.00.MD
@@ -117,15 +117,20 @@
 - Added ability to prevent certain users from adding events to lists 
 - Added ability to bypass the Aspen event pages
 - "Add to Your Events and Register" button separated into two buttons, one for registration information and one for adding to your events
+- Add an option for libraries to show a custom modal for linking out to event registration pages (if modal body field is empty, no modal will show and user will be redirected to external event page)
+
 <div markdown="1" class="settings">
 
 #### New Settings
 - Events -> LibraryMarket - Library Calendar Settings -> Events in Lists
 - Events -> LibraryMarket - Library Calendar Settings -> Bypass event pages in Aspen
+- Events -> LibraryMarket - Library Calendar Settings -> Registration Modal Body
 - Events -> Springshare - LibCal Settings -> Events in Lists
 - Events -> Springshare - LibCal Settings -> Bypass event pages in Aspen
+- Events -> Springshare - LibCal Settings -> Registration Modal Body
 - Events -> Communico - Attend Settings -> Events in Lists
 - Events -> Communico - Attend Settings -> Bypass event pages in Aspen
+- Events -> Communico - Attend Settings -> Registration Modal Body
 </div>
 
 //other organizations

--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -3124,6 +3124,7 @@ class MyAccount_AJAX extends JSON_Action {
 					'title' => $entry->title,
 					'link' => $eventRecordDriver->getLinkUrl(),
 					'externalLink' => $eventRecordDriver->getExternalUrl(),
+					'regModalBody' => $eventRecordDriver->getRegistrationModalBody(),
 					'location' => $entry->location,
 					'regRequired' => $entry->regRequired,
 					'isRegistered' => $registration,
@@ -5801,6 +5802,23 @@ class MyAccount_AJAX extends JSON_Action {
 			}
 		}
 		return $result;
+	}
+
+	/** @noinspection PhpUnused */
+	function eventRegistrationModal() {
+		$eventUrl = $_REQUEST['regLink'];
+		return [
+			'success' => true,
+			'title' => translate([
+				'text' => 'Registration Information',
+				'isPublicFacing' => true,
+			]),
+			'buttons' => '<a href="' .$eventUrl. '" class="btn btn-sm btn-info btn-wrap" target="_blank"><i class="fas fa-external-link-alt"></i>'
+				. translate([
+					'text' => 'Take Me To Event Registration',
+					'isPublicFacing' => true,
+				]) . '</a>',
+		];
 	}
 
 	/** @noinspection PhpUnused */

--- a/code/web/sys/Covers/BookCoverProcessor.php
+++ b/code/web/sys/Covers/BookCoverProcessor.php
@@ -1034,7 +1034,7 @@ class BookCoverProcessor {
 
 	function omdb(OMDBSetting $omdbSettings, $title = null, $shortTitle = null, $year = '') {
 		//Only load from google if we are looking at a grouped work to be sure uploaded covers have a chance to load
-		if ($this->type != 'grouped_work' || !$this->bookCoverInfo->disallowThirdPartyCover) {
+		if ($this->type != 'grouped_work' || $this->bookCoverInfo->disallowThirdPartyCover) {
 			return false;
 		}
 

--- a/code/web/sys/DBMaintenance/version_updates/23.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.08.00.php
@@ -119,6 +119,15 @@ function getUpdates23_08_00(): array {
 				'ALTER TABLE communico_settings ADD COLUMN bypassAspenEventPages tinyint(1) default 0',
 			],
 		], //bypass_event_pages
+		'event_registration_modal' => [
+			'title' => 'Event Registration Modal',
+			'description'=> 'Add settings for modal for event registration information',
+			'sql' => [
+				'ALTER TABLE lm_library_calendar_settings ADD COLUMN registrationModalBody mediumtext',
+				'ALTER TABLE springshare_libcal_settings ADD COLUMN registrationModalBody mediumtext',
+				'ALTER TABLE communico_settings ADD COLUMN registrationModalBody mediumtext',
+			],
+		], //event_registration_modal
 
 		//other organizations
 

--- a/code/web/sys/Events/CommunicoSetting.php
+++ b/code/web/sys/Events/CommunicoSetting.php
@@ -18,6 +18,7 @@ class CommunicoSetting extends DataObject {
 		$clientSecret;
 	public $eventsInLists;
 	public $bypassAspenEventPages;
+	public $registrationModalBody;
 	public $username;
 	public $password;
 
@@ -81,6 +82,14 @@ class CommunicoSetting extends DataObject {
 				'label' => 'Bypass event pages in Aspen',
 				'description' => 'Whether or not a user will be redirected to an Aspen event page or the page for the native event platform.',
 				'default' => 0,
+			],
+			'registrationModalBody' => [
+				'property' => 'registrationModalBody',
+				'type' => 'html',
+				'label' => 'Registration Modal Body',
+				'description' => 'The body of the modal for event registration information',
+				'allowableTags' => '<p><em><i><strong><b><a><ul><ol><li><h1><h2><h3><h4><h5><h6><h7><pre><code><hr><table><tbody><tr><th><td><caption><img><br><div><span><sub><sup>',
+				'hideInLists' => true,
 			],
 
 			'libraries' => [

--- a/code/web/sys/Events/LMLibraryCalendarSetting.php
+++ b/code/web/sys/Events/LMLibraryCalendarSetting.php
@@ -17,6 +17,7 @@ class LMLibraryCalendarSetting extends DataObject {
 		$clientSecret;
 	public $eventsInLists;
 	public $bypassAspenEventPages;
+	public $registrationModalBody;
 	public $username;
 	public $password;
 
@@ -97,6 +98,14 @@ class LMLibraryCalendarSetting extends DataObject {
 				'label' => 'Bypass event pages in Aspen',
 				'description' => 'Whether or not a user will be redirected to an Aspen event page or the page for the native event platform.',
 				'default' => 0,
+			],
+			'registrationModalBody' => [
+				'property' => 'registrationModalBody',
+				'type' => 'html',
+				'label' => 'Registration Modal Body',
+				'description' => 'The body of the modal for event registration information',
+				'allowableTags' => '<p><em><i><strong><b><a><ul><ol><li><h1><h2><h3><h4><h5><h6><h7><pre><code><hr><table><tbody><tr><th><td><caption><img><br><div><span><sub><sup>',
+				'hideInLists' => true,
 			],
 
 			'libraries' => [

--- a/code/web/sys/Events/SpringshareLibCalSetting.php
+++ b/code/web/sys/Events/SpringshareLibCalSetting.php
@@ -18,6 +18,7 @@ class SpringshareLibCalSetting extends DataObject {
 		$clientSecret;
 	public $eventsInLists;
 	public $bypassAspenEventPages;
+	public $registrationModalBody;
 	public $username;
 	public $password;
 
@@ -88,6 +89,14 @@ class SpringshareLibCalSetting extends DataObject {
 				'label' => 'Bypass event pages in Aspen',
 				'description' => 'Whether or not a user will be redirected to an Aspen event page or the page for the native event platform.',
 				'default' => 0,
+			],
+			'registrationModalBody' => [
+				'property' => 'registrationModalBody',
+				'type' => 'html',
+				'label' => 'Registration Modal Body',
+				'description' => 'The body of the modal for event registration information',
+				'allowableTags' => '<p><em><i><strong><b><a><ul><ol><li><h1><h2><h3><h4><h5><h6><h7><pre><code><hr><table><tbody><tr><th><td><caption><img><br><div><span><sub><sup>',
+				'hideInLists' => true,
 			],
 
 			'libraries' => [


### PR DESCRIPTION
Add an option for libraries to show a custom modal for linking out to event registration pages (if modal body field is empty, no modal will show and user will be redirected to external event page)
New columns added to event settings tables for registrationModalBody
Updated Your Events - no more "Is Registration Required?" column & "Check Registration" button follows new modal rules
Updated release notes