### PR TITLE
Footer company variable

### DIFF
--- a/code/web/index.php
+++ b/code/web/index.php
@@ -234,6 +234,18 @@ if (UserAccount::isLoggedIn() && UserAccount::userHasPermission('Submit Ticket')
 	}
 }
 
+//system variable for supporting company name
+$interface->assign('supportingCompany', 'ByWater Solutions');
+try {
+	require_once ROOT_DIR . '/sys/SystemVariables.php';
+	$systemVariables = new SystemVariables();
+	if ($systemVariables->find(true)) {
+		$interface->assign('supportingCompany', $systemVariables->supportingCompany);
+	}
+} catch (Exception $e) {
+	//No error raised else error would occur on install when no system variables have been defined
+}
+
 $deviceName = get_device_name();
 $interface->assign('deviceName', $deviceName);
 

--- a/code/web/interface/themes/responsive/footer_responsive.tpl
+++ b/code/web/interface/themes/responsive/footer_responsive.tpl
@@ -3,7 +3,7 @@
 	<div class="navbar-inner">
 		<div class="row {if !empty($fullWidthTheme)}row-no-gutters{/if}">
 			<div class="col-tn-12 col-sm-5 col-md-4 text-left" id="install-info">
-				<small>{translate text='Powered By Aspen Discovery supported by ByWater Solutions' isPublicFacing=true}</small><br>
+				<small>{translate text='Powered By Aspen Discovery supported by' isPublicFacing=true} {$supportingCompany}</small><br>
 				{if empty($productionServer)}
 					<small class='location_info'>{$physicalLocation}{if !empty($debug)} ({$activeIp}){/if} - {$deviceName}</small>
 				{/if}

--- a/code/web/release_notes/23.08.00.MD
+++ b/code/web/release_notes/23.08.00.MD
@@ -137,6 +137,9 @@
 </div>
 
 //other organizations
+//PTFS - Europe
+## System Variables
+- Added an option to the System Variables to allow the name of the company providing support to be edited (set to ByWater Solutions by default)
 
 ## This release includes code contributions from
 - ByWater Solutions

--- a/code/web/sys/DBMaintenance/version_updates/23.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.08.00.php
@@ -142,5 +142,15 @@ function getUpdates23_08_00(): array {
 			]
 		], //secondary phone number
 
+		//Alexander - PTFS
+		'add_supporting_company_system_variables' => [
+			'title' => 'Add supporting company into system variables',
+			'description' => 'Add column to set name of company undertaking installation',
+			'continueOnError' => false,
+			'sql' => [
+				"ALTER TABLE system_variables ADD COLUMN supportingCompany VARCHAR(72) default 'ByWater Solutions'",
+			]
+		],
+
 	];
 }

--- a/code/web/sys/Interface.php
+++ b/code/web/sys/Interface.php
@@ -1011,6 +1011,24 @@ class UInterface extends Smarty {
 			if ($footerLogoAlt) {
 				$this->assign('footerLogoAlt', $footerLogoAlt);
 			}
+			
+			
+			$systemVariables = SystemVariables::getSystemVariables();
+			$supportingCompany = $systemVariables->supportingCompany;
+	
+
+			if(!empty ($supportingCompany)) {
+				$this->assign('supportingCompany', $supportingCompany);
+			}
+
+
+			$systemVariables = SystemVariables::getSystemVariables();
+			$supportingCompany = $systemVariables->supportingCompany;
+
+
+			if(!empty ($supportingCompany)) {
+				$this->assign('supportingCompany', $supportingCompany);
+			}
 
 			//Get favicon
 			$favicon = null;

--- a/code/web/sys/SystemVariables.php
+++ b/code/web/sys/SystemVariables.php
@@ -27,6 +27,7 @@ class SystemVariables extends DataObject {
 	public $catalogStatus;
 	public $offlineMessage;
 	public $appScheme;
+	public $supportingCompany;
 	public $googleBucket;
 	public $trackIpAddresses;
 	public $allowScheduledUpdates;
@@ -271,6 +272,13 @@ class SystemVariables extends DataObject {
 				'type' => 'text',
 				'label' => 'App Scheme',
 				'description' => 'Scheme used for creating deep links into the app',
+			],
+			'supportingCompany' => [
+				'property' => 'supportingCompany',
+				'type' => 'text',
+				'label' => 'Company completing installation',
+				'description' => 'Sets supporing company name in footer',
+				'default' => 'ByWater Solutions',
 			],
 			'trackIpAddresses' => [
 				'property' => 'trackIpAddresses',


### PR DESCRIPTION
Allows the company name in the footer to be set in system variables. Defaults to ByWater Solutions if not changed.

Test Plan:

1.Scroll to the footer on any of the pages on an Aspen site and note that it says supported by ByWater Solutions.
2.Navigate to Administration and then to Database Maintenance and complete updates.
3.Navigate to System Variables within Administration and click edit.
4.The last box should now be an option to edit the name of the supporting company.
5.Edit the company name if needed and save the changes.
6.Ensure that the footer reflects the changes.