### PR TITLE
Cookie consent enhancements

### DIFF
--- a/code/web/index.php
+++ b/code/web/index.php
@@ -239,10 +239,10 @@ if (UserAccount::isLoggedIn() && UserAccount::userHasPermission('Submit Ticket')
 //Check to see if we should show the cookieConsent banner
 $interface->assign('cookieStorageConsent', false);
 $interface->assign('cookieStorageConsentHTML', '');
-if (!empty($systemVariables) && !empty($systemVariables->cookieStorageConsent)) {
+if (!empty($library) && !empty($library->cookieStorageConsent)) {
 	try {
 		$interface->assign('cookieStorageConsent', true);
-		$interface->assign('cookieStorageConsentHTML', $systemVariables->cookiePolicyHTML);
+		$interface->assign('cookieStorageConsentHTML', $library->cookiePolicyHTML);
 	} catch (Exception $e) {
 		//Not yet setup. Ignore
 	}

--- a/code/web/interface/themes/responsive/css/cookie-consent.less
+++ b/code/web/interface/themes/responsive/css/cookie-consent.less
@@ -1,25 +1,22 @@
 .stripPopup{
     margin: 0;
     box-sizing: border-box;
-    background-color: rgb(29, 127, 240);
     padding: 15px 0;
     position: fixed;
     bottom: 0;
     left: 0;
     width: 100%;
-    z-index: 1;
+    z-index: 1038;
     font-family: sans-serif;
 
     .btnWrap{
         a.button{
             width:188px;
-            color: white;
             padding: 12px 10px;
             font-size: 12px;
             font-weight: 700;
             line-height: normal;
             text-align: center;
-            border: 1px solid white;
             margin: 2px 5px 0;
             display: inline-block; 
             text-decoration: none;
@@ -29,7 +26,6 @@
            
         }
             a.button:hover{
-                background-color: red;
                 transition: all .3s ease-in-out;
                 -webkit-transition: all .3s ease-in-out;
                 -moz-transition: all .3s ease-in-out;
@@ -52,13 +48,11 @@
 
             span{
                 font-size: 14px;
-                color: #fff;
                 font-weight: 700;
                 display: block;
             }
             abbr {
                 font-size: 12px;
-                color: white;
                 font-weight: 400;
                 display: block;
             }

--- a/code/web/interface/themes/responsive/css/layout.less
+++ b/code/web/interface/themes/responsive/css/layout.less
@@ -912,3 +912,25 @@ a.placard-link{
   height: 60px;
   width: 60px;
 }
+
+.stripPopup {
+  background-color: rgb(29, 127, 240);
+  .btnWrap {
+    a.button {
+      color: white;
+      border: 1px solid white;
+    }
+    a.button:hover {
+      background-color: red;
+    }
+  }
+  .cookieContainer{
+    span {
+      color: #fff;
+    }
+
+    abbr {
+      color: white;
+    }
+  }
+}

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -8699,6 +8699,22 @@ a.placard-link {
   height: 60px;
   width: 60px;
 }
+.stripPopup {
+  background-color: #1d7ff0;
+}
+.stripPopup .btnWrap a.button {
+  color: white;
+  border: 1px solid white;
+}
+.stripPopup .btnWrap a.button:hover {
+  background-color: red;
+}
+.stripPopup .cookieContainer span {
+  color: #fff;
+}
+.stripPopup .cookieContainer abbr {
+  color: white;
+}
 #home-page-search {
   background-color: #00a4e3;
   padding: 20px 0 10px;
@@ -10940,24 +10956,21 @@ input[type="radio"][name="colorScheme"]:checked + label::after {
 .stripPopup {
   margin: 0;
   box-sizing: border-box;
-  background-color: #1d7ff0;
   padding: 15px 0;
   position: fixed;
   bottom: 0;
   left: 0;
   width: 100%;
-  z-index: 1;
+  z-index: 1038;
   font-family: sans-serif;
 }
 .stripPopup .btnWrap a.button {
   width: 188px;
-  color: white;
   padding: 12px 10px;
   font-size: 12px;
   font-weight: 700;
   line-height: normal;
   text-align: center;
-  border: 1px solid white;
   margin: 2px 5px 0;
   display: inline-block;
   text-decoration: none;
@@ -10966,7 +10979,6 @@ input[type="radio"][name="colorScheme"]:checked + label::after {
   -moz-transition: all 0.3s ease-in-out;
 }
 .stripPopup .btnWrap a.button:hover {
-  background-color: red;
   transition: all 0.3s ease-in-out;
   -webkit-transition: all 0.3s ease-in-out;
   -moz-transition: all 0.3s ease-in-out;
@@ -10987,13 +10999,11 @@ input[type="radio"][name="colorScheme"]:checked + label::after {
 }
 .stripPopup .cookieContainer .contentWrap span {
   font-size: 14px;
-  color: #fff;
   font-weight: 700;
   display: block;
 }
 .stripPopup .cookieContainer .contentWrap abbr {
   font-size: 12px;
-  color: white;
   font-weight: 400;
   display: block;
 }

--- a/code/web/interface/themes/responsive/theme.css.tpl
+++ b/code/web/interface/themes/responsive/theme.css.tpl
@@ -853,7 +853,25 @@ color: {$bodyTextColor};
         font-size: 85%;
     {rdelim}
 {/if}
-
+/* cookieConsent */
+.stripPopup {ldelim}
+  background-color: {$cookieConsentBackgroundColor};
+{rdelim}
+.stripPopup .btnWrap a.button {ldelim}
+background-color: {$cookieConsentButtonColor};
+color: {$cookieConsentButtonTextColor};
+border: 1px solid {$cookieConsentButtonBorderColor};
+{rdelim}
+.stripPopup .btnWrap a.button:hover {ldelim}
+background-color: {$cookieConsentButtonHoverColor};
+color: {$cookieConsentButtonHoverTextColor};
+{rdelim}
+.stripPopup .cookieContainer .contentWrap span {ldelim}
+  color: {$cookieConsentTextColor};
+{rdelim}
+.stripPopup .cookieContainer .contentWrap abbr {ldelim}
+  color: {$cookieConsentTextColor};
+{rdelim}
 {$additionalCSS}
 </style>
 {/strip}

--- a/code/web/release_notes/23.08.00.MD
+++ b/code/web/release_notes/23.08.00.MD
@@ -142,12 +142,12 @@
 - Fix issue where image source = "Not Available" for all works
 - Add .SOURCE. and .GEN_NOTE. to Symphony as leading note phrases for non-public notes
 - Added an option to the System Variables to allow the name of the company providing support to be edited (set to ByWater Solutions by default)
-- Add cookie consent banner and accompanying system variables to enable/disable.
-- Add policy page html system variable to be displayed to end user from cookie consent banner when enabled.
+- Add cookie consent banner and accompanying Library System settings to enable/disable.
+- Add policy page html Library System settings to be displayed to end user from cookie consent banner when enabled.
 - Properly check for empty messages when blocking patrons from a particular library from logging in or blocking patrons from other libraries from logging in. 
 - Increase crawl delay to 20 in robots.txt
-- Fix error when emailing lists that caused publication date to not show.   
-- Move IP tracking to new 'Data Protection' section in system variables.
+- Fix error when emailing lists that caused publication date to not show.
+- Add themeing options for cookie consent banner
 
 <div markdown="1" class="settings">
 

--- a/code/web/sys/DBMaintenance/version_updates/23.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.08.00.php
@@ -160,5 +160,28 @@ function getUpdates23_08_00(): array {
 			]
 		],
 
+		//Jacob - PTFS
+		'add_cookie_consent_theming' => [
+			'title' => 'Add theming to Cookie Consent banner',
+			'description' => 'Adds column to specify cookie consent colors in themes',
+			'continueOnError' => true,
+			'sql' => [
+				"ALTER TABLE themes ADD COLUMN cookieConsentBackgroundColor CHAR(7) DEFAULT '#1D7FF0'",
+				'ALTER TABLE themes ADD COLUMN cookieConsentBackgroundColorDefault tinyint(1) DEFAULT 1',
+				"ALTER TABLE themes ADD COLUMN cookieConsentButtonColor CHAR(7) DEFAULT '#1D7FF0'",
+				'ALTER TABLE themes ADD COLUMN cookieConsentButtonColorDefault tinyint(1) DEFAULT 1',
+				"ALTER TABLE themes ADD COLUMN cookieConsentButtonHoverColor CHAR(7) DEFAULT '#FF0000'",
+				'ALTER TABLE themes ADD COLUMN cookieConsentButtonHoverColorDefault tinyint(1) DEFAULT 1',
+				"ALTER TABLE themes ADD COLUMN cookieConsentTextColor CHAR(7) DEFAULT '#FFFFFF'",
+				'ALTER TABLE themes ADD COLUMN cookieConsentTextColorDefault tinyint(1) DEFAULT 1',
+				"ALTER TABLE themes ADD COLUMN cookieConsentButtonTextColor CHAR(7) DEFAULT '#FFFFFF'",
+				'ALTER TABLE themes ADD COLUMN cookieConsentButtonTextColorDefault tinyint(1) DEFAULT 1',
+				"ALTER TABLE themes ADD COLUMN cookieConsentButtonHoverTextColor CHAR(7) DEFAULT '#FFFFFF'",
+				'ALTER TABLE themes ADD COLUMN cookieConsentButtonHoverTextColorDefault tinyint(1) DEFAULT 1',
+				"ALTER TABLE themes ADD COLUMN cookieConsentButtonBorderColor CHAR(7) DEFAULT '#FFFFFF'",
+				'ALTER TABLE themes ADD COLUMN cookieConsentButtonBorderColorDefault tinyint(1) DEFAULT 1',
+			]
+		],
+		//add theming to cookieConsent banner
 	];
 }

--- a/code/web/sys/DBMaintenance/version_updates/23.08.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.08.00.php
@@ -183,5 +183,17 @@ function getUpdates23_08_00(): array {
 			]
 		],
 		//add theming to cookieConsent banner
+		'move_cookieConsent_to_library_settings' => [
+			'title' => 'Move Cookie Consent toggle to library settings',
+			'description' => 'Moves the cookie consent toggle from system settings to library settings',
+			'continueOnError' => true,
+			'sql' => [
+				"ALTER TABLE system_variables DROP COLUMN cookieStorageConsent",
+				"ALTER TABLE system_variables DROP COLUMN cookiePolicyHTML",
+				"ALTER TABLE library ADD COLUMN cookieStorageConsent tinyint(1) DEFAULT 0",
+				"ALTER TABLE library ADD COLUMN cookiePolicyHTML TEXT",
+				"UPDATE library set cookiePolicyHTML = 'This body has not yet set a cookie storage policy, please check back later.'",
+			]
+		]
 	];
 }

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -406,6 +406,10 @@ class Library extends DataObject {
 
 	public $accountProfileId;
 
+	//cookieConsent
+	public $cookieStorageConsent;
+	public $cookiePolicyHTML;
+
 	private $_cloudLibraryScopes;
 	private $_libraryLinks;
 
@@ -3168,6 +3172,30 @@ class Library extends DataObject {
 						],
 					],
 				],
+			],
+			'dataProtectionRegulations' => [
+				'property' => 'dataProtectionRegulations',
+				'type' => 'section',
+				'label' => 'Data Protection Regulations',
+				'hideInLists' => true,
+				'expandByDefault' => false,
+				'properties' => [
+					'cookieStorageConsent' => [
+						'property' => 'cookieStorageConsent',
+						'type' => 'checkbox',
+						'label' => 'Require Cookie Storage Consent',
+						'description' => 'Require users to consent to cookie storage before using the catalog',
+						'default' => false,
+					],
+					'cookiePolicyHTML' => [
+						'property' => 'cookiePolicyHTML',
+						'type' => 'html',
+						'label' => 'Cookie Policy',
+						'description' => 'HTML of cookie policy to display to users',
+						'default' => 'This body has not yet set a cookie storage policy, please check back later.',
+						'hideInLists' => true,
+					],
+				]
 			],
 			'messagingSection' => [
 				'property' => 'messagingSection',

--- a/code/web/sys/SystemVariables.php
+++ b/code/web/sys/SystemVariables.php
@@ -32,8 +32,7 @@ class SystemVariables extends DataObject {
 	public $trackIpAddresses;
 	public $allowScheduledUpdates;
 	public $doQuickUpdates;
-	public $cookieStorageConsent;
-	public $cookiePolicyHTML;
+
 
 	static function getObjectStructure($context = ''): array {
 		return [
@@ -282,36 +281,12 @@ class SystemVariables extends DataObject {
 				'description' => 'Sets supporting company name in footer',
 				'default' => 'ByWater Solutions',
 			],
-			'dataProtectionRegulations' => [
-				'property' => 'dataProtectionRegulations',
-				'type' => 'section',
-				'label' => 'Data Protection Regulations',
-				'hideInLists' => true,
-				'expandByDefault' => true,
-				'properties' => [
-					'cookieStorageConsent' => [
-						'property' => 'cookieStorageConsent',
-						'type' => 'checkbox',
-						'label' => 'Require Cookie Storage Consent',
-						'description' => 'Require users to consent to cookie storage before using the catalog',
-						'default' => false,
-					],
-					'cookiePolicyHTML' => [
-						'property' => 'cookiePolicyHTML',
-						'type' => 'html',
-						'label' => 'Cookie Policy',
-						'description' => 'HTML of cookie policy to display to users',
-						'default' => 'This body has not yet set a cookie storage policy, please check back later.',
-						'hideInLists' => true,
-					],
-					'trackIpAddresses' => [
+			'trackIpAddresses' => [
 						'property' => 'trackIpAddresses',
 						'type' => 'checkbox',
 						'label' => 'Track IP Addresses',
 						'description' => 'Determine if IP Addresses should be tracked for each page view',
 						'default' => false,
-					]
-				]
 			],
 		];
 	}

--- a/code/web/sys/Theming/Theme.php
+++ b/code/web/sys/Theming/Theme.php
@@ -434,6 +434,36 @@ class Theme extends DataObject {
 
 	public $generatedCss;
 
+	//Cookie Consent Themeing Options
+	public $cookieConsentBackgroundColor;
+	public /** @noinspection PhpUnused */
+		$cookieConsentBackgroundColorDefault;
+
+	public $cookieConsentButtonColor;
+	public /** @noinspection PhpUnused */
+		$cookieConsentButtonColorDefault;
+	
+	public $cookieConsentButtonHoverColor;
+	public /** @noinspection PhpUnused */
+		$cookieConsentButtonHoverColorDefault;
+
+	public $cookieConsentTextColor;
+	public /** @noinspection PhpUnused */
+		$cookieConsentTextColorDefault;
+
+	public $cookieConsentButtonTextColor;
+	public /** @noinspection PhpUnused */
+		$cookieConsentButtonTextColorDefault;
+
+	public $cookieConsentButtonHoverTextColor;
+	public /** @noinspection PhpUnused */
+		$cookieConsentButtonHoverTextColorDefault;
+	
+	public $cookieConsentButtonBorderColor;
+	public /** @noinspection PhpUnused */
+		$cookieConsentButtonBorderColorDefault;
+
+
 	private $_libraries;
 	private $_locations;
 
@@ -2060,6 +2090,83 @@ class Theme extends DataObject {
 					],
 				]
 			],
+			'cookieConsentSection' => [
+				'property' => 'cookieConsentSection',
+				'type' => 'section',
+				'label' => 'Cookie Consent',
+				'hideInLists' => true,
+				'properties' => [
+					'cookieConsentBackgroundColor' => [
+						'property' => 'cookieConsentBackgroundColor',
+						'type' => 'color',
+						'label' => 'Cookie Consent Banner Color',
+						'description' => 'Cookie Consent Banner Background Color',
+						'required' => false,
+						'hideInLists' => true,
+						'default' => '#1D7FF0',
+						'checkContrastWith' => 'cookieConsentTextColor',
+					],
+					'cookieConsentTextColor' => [
+						'property' => 'cookieConsentTextColor',
+						'type' => 'color',
+						'label' => 'Cookie Consent Text Color',
+						'description' => 'Color Of Text In Cookie Consent Bar Color',
+						'required' => false,
+						'hideInLists' => true,
+						'default' => '#FFFFFF',
+						'checkContrastWith' => 'cookieConsentBackgroundColor',
+					],
+					'cookieConsentButtonColor' => [
+						'property' => 'cookieConsentButtonColor',
+						'type' => 'color',
+						'label' => 'Cookie Consent Button Color',
+						'description' => 'Base Color Of Cookie Consent Buttons',
+						'required' => false,
+						'hideInLists' => true,
+						'default' => '#1D7FF0',
+						'checkContrastWith' => 'cookieConsentButtonTextColor',
+					],
+					'cookieConsentButtonTextColor' => [
+						'property' => 'cookieConsentButtonTextColor',
+						'type' => 'color',
+						'label' => 'Cookie Consent Button Text Color',
+						'description' => 'Color Of Text In Cookie Consent Buttons On Hover',
+						'required' => false,
+						'hideInLists' => true,
+						'default' => '#FFFFFF',
+						'checkContrastWith' => 'cookieConsentButtonColor',
+					],
+					'cookieConsentButtonHoverColor' => [
+						'property' => 'cookieConsentButtonHoverColor',
+						'type' => 'color',
+						'label' => 'Cookie Consent Button Hover Color',
+						'description' => 'Color of Cookie Consent Buttons on Hover',
+						'required' => false,
+						'hideInLists' => true,
+						'default' => '#FF0000',
+						'checkContrastWith' => 'cookieConsentButtonHoverTextColor',
+					],
+					'cookieConsentButtonHoverTextColor' => [
+						'property' => 'cookieConsentButtonHoverTextColor',
+						'type' => 'color',
+						'label' => 'Cookie Consent Button Hover Text Color',
+						'description' => 'Color Of Text In Cookie Consent Buttons On Hover',
+						'required' => false,
+						'hideInLists' => true,
+						'default' => '#FFFFFF',
+						'checkContrastWith' => 'cookieConsentButtonHoverColor',
+					],
+					'cookieConsentButtonBorderColor' => [
+						'property' => 'cookieConsentButtonBorderColor',
+						'type' => 'color',
+						'label' => 'Cookie Consent Button Border Color',
+						'description' => 'Color Of Border around Buttons in Cookie Consent Banner',
+						'required' => false,
+						'hideInLists' => true,
+						'default' => '#FFFFFF',
+					],
+				],
+			],
 
 			'libraries' => [
 				'property' => 'libraries',
@@ -2473,6 +2580,13 @@ class Theme extends DataObject {
 		$this->getValueForPropertyUsingDefaults('dangerButtonHoverBackgroundColor', Theme::$defaultDangerButtonHoverBackgroundColor, $appliedThemes);
 		$this->getValueForPropertyUsingDefaults('dangerButtonHoverForegroundColor', Theme::$defaultDangerButtonHoverForegroundColor, $appliedThemes);
 		$this->getValueForPropertyUsingDefaults('dangerButtonHoverBorderColor', Theme::$defaultDangerButtonHoverBorderColor, $appliedThemes);
+		$this->getValueForPropertyUsingDefaults('cookieConsentBackgroundColor', '#1D7FF0', $appliedThemes);
+		$this->getValueForPropertyUsingDefaults('cookieConsentButtonColor', '#1D7FF0', $appliedThemes);
+		$this->getValueForPropertyUsingDefaults('cookieConsentButtonHoverColor', '#FF0000', $appliedThemes);
+		$this->getValueForPropertyUsingDefaults('cookieConsentTextColor', '#FFFFFF', $appliedThemes);
+		$this->getValueForPropertyUsingDefaults('cookieConsentButtonTextColor', '#FFFFFF', $appliedThemes);
+		$this->getValueForPropertyUsingDefaults('cookieConsentButtonHoverTextColor', '#FFFFFF', $appliedThemes);
+		$this->getValueForPropertyUsingDefaults('cookieConsentButtonBorderColor', '#FFFFFF', $appliedThemes);
 	}
 
 	public function getValueForPropertyUsingDefaults($propertyName, $defaultValue, $appliedThemes) {
@@ -2606,6 +2720,14 @@ class Theme extends DataObject {
 		$interface->assign('dangerButtonHoverForegroundColor', $this->dangerButtonHoverForegroundColor);
 		$interface->assign('dangerButtonHoverBorderColor', $this->dangerButtonHoverBorderColor);
 		$interface->assign('themeIsHighContrast', $this->isHighContrast);
+		$interface->assign('cookieConsentBackgroundColor', $this->cookieConsentBackgroundColor);
+		$interface->assign('cookieConsentButtonColor', $this->cookieConsentButtonColor);
+		$interface->assign('cookieConsentButtonHoverColor', $this->cookieConsentButtonHoverColor);
+		$interface->assign('cookieConsentTextColor', $this->cookieConsentTextColor);
+		$interface->assign('cookieConsentButtonTextColor', $this->cookieConsentButtonTextColor);
+		$interface->assign('cookieConsentButtonHoverTextColor', $this->cookieConsentButtonHoverTextColor);
+		$interface->assign('cookieConsentButtonBorderColor', $this->cookieConsentButtonBorderColor);
+		
 
 		foreach ($allAppliedThemes as $theme) {
 			if ($interface->getVariable('headingFont') == null && !$theme->headingFontDefault) {


### PR DESCRIPTION
This PR adds the ability to customise the cookie consent bar using the theming menu
Additionally, also allows you to set cookie consent enabled/disabled and have a separate cookie consent policy per library system.

Test Plan:

Apply Patch
Run DB maintenance.
Navigate to main Library System and make sure a theme is set in "Basic Display" settings
In same library system, set cookie consent to enabled.
Cookie consent should now appear with default blue scheme
Test functionality
Navigate to Theme settings in Aspen Administration
Change Cookie Consent Colorway
Check that Colors have applied on save
Navigate to another Library system and enable a different theme.
Enable cookie consent and make library system your new default
Cookie Consent should have alternate theming based on this Library system's settings.