### PR TITLE
Barcode with "+"

### DIFF
--- a/code/web/Drivers/OverDriveDriver.php
+++ b/code/web/Drivers/OverDriveDriver.php
@@ -244,6 +244,7 @@ class OverDriveDriver extends AbstractEContentDriver {
 					"User-Agent: Aspen Discovery " . $interface->getVariable('gitBranch'),
 				], true);
 
+				$patronBarcode = urlencode($patronBarcode);
 				if ($patronPin == null) {
 					$postFields = "grant_type=password&username={$patronBarcode}&password=ignore&password_required=false&scope=websiteId:{$websiteId}%20ilsname:{$ilsname}";
 				} else {

--- a/code/web/release_notes/23.09.00.MD
+++ b/code/web/release_notes/23.09.00.MD
@@ -117,8 +117,9 @@
 - Added SIP function to handle barcode self-checkout with the ILS.
 - Added API endpoint in the User API to support barcode self-checkout.
 - Fixed an issue where bots were generating errors with old saved searches
-- Fixed an issue where the usage dashboard was incorrectly showing "0" values (tickets 118478, 119854)
+- Fixed an issue where the usage dashboard was incorrectly showing "0" values (Tickets 118478, 119854)
 - Allow Solr server to be specified when creating new sites.
+- Fix issue where barcodes with a "+" couldn't check out Overdrive items (Ticket 118889)
 
 ## This release includes code contributions from
 - ByWater Solutions


### PR DESCRIPTION
Fix issue where barcodes with a "+" couldn't check out Overdrive items 
Updated release notes