### PR TITLE
Use supplied db host when creating new database

### DIFF
--- a/install/createSite.php
+++ b/install/createSite.php
@@ -304,7 +304,7 @@ exec("$mysqlConnectionCommand {$variables['aspenDBName']} < $installDir/install/
 
 
 //Connect to the database
-$aspen_db = new PDO("mysql:dbname={$variables['aspenDBName']};host=localhost",$variables['aspenDBUser'],$variables['aspenDBPwd']);
+$aspen_db = new PDO("mysql:dbname={$variables['aspenDBName']};host={$variables['aspenDBHost']}",$variables['aspenDBUser'],$variables['aspenDBPwd']);
 $updateUserStmt = $aspen_db->prepare("UPDATE user set cat_password=" . $aspen_db->quote($variables['aspenAdminPwd']) . ", password=" . $aspen_db->quote($variables['aspenAdminPwd']) . " where username = 'aspen_admin'");
 $updateUserStmt->execute();
 


### PR DESCRIPTION
If given a non-localhost database host use it when initially creating the new db.