### PR TITLE
Refactor: Mobile browsing tabs

### DIFF
--- a/code/web/interface/themes/responsive/css-rtl/main.css
+++ b/code/web/interface/themes/responsive/css-rtl/main.css
@@ -10202,10 +10202,24 @@ a.browse-thumbnail.active {
   }
   #availabilityControl button {
     padding: 5px 10px;
-    font-size: 12px;
-    line-height: 1.5;
+    font-size: 10px;
+    line-height: 1.2;
     border-radius: 3px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 2.5em;
   }
+}
+#availabilityControl button {
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.2;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 3.5em;
 }
 .search-results-navigation {
   display: flex;

--- a/code/web/interface/themes/responsive/css-rtl/results-list.less
+++ b/code/web/interface/themes/responsive/css-rtl/results-list.less
@@ -289,11 +289,28 @@
     padding-left: 0;
   }
   #availabilityControl button {
-    .btn-sm();
+    padding: 5px 10px;
+    font-size: 10px;
+    line-height: 1.2;
+    border-radius: 3px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 2.5em;
   }
   //.title-rating {
   //  display: none;
   //}
+}
+#availabilityControl button {
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.2;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 3.5em;
 }
 
 //// Hide Formats label when shown in modal pop-up

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -2,6 +2,7 @@
 @import "lib/rome.min.css";
 @import "simplemde.min.css";
 @import "lib/Chart.min.css";
+@import "variables.less";
 article,
 aside,
 details,
@@ -10353,10 +10354,24 @@ a.browse-thumbnail.active {
   }
   #availabilityControl button {
     padding: 5px 10px;
-    font-size: 12px;
-    line-height: 1.5;
+    font-size: 10px;
+    line-height: 1.2;
     border-radius: 3px;
-  }
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 2.5em;
+    }
+}
+#availabilityControl button {
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.2;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 3.5em;
 }
 .search-results-navigation {
   display: flex;

--- a/code/web/interface/themes/responsive/css/results-list.less
+++ b/code/web/interface/themes/responsive/css/results-list.less
@@ -289,11 +289,28 @@
     padding-right: 0;
   }
   #availabilityControl button {
-    .btn-sm();
+    padding: 5px 10px;
+    font-size: 10px;
+    line-height: 1.2;
+    border-radius: 3px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 2.5em;
   }
   //.title-rating {
   //  display: none;
   //}
+}
+#availabilityControl button {
+  padding: 5px 10px;
+  font-size: 12px;
+  line-height: 1.2;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 3.5em;
 }
 
 //// Hide Formats label when shown in modal pop-up

--- a/code/web/release_notes/23.10.10.MD
+++ b/code/web/release_notes/23.10.10.MD
@@ -1,0 +1,19 @@
+## Aspen LiDA Updates
+- 
+
+## Aspen Discovery Updates
+//mark
+
+//kirstien
+
+//kodi
+
+//alexander
+
+//jacob
+
+//lucas
+
+
+## This release includes code contributions from
+- ByWater Solutions

--- a/code/web/release_notes/23.11.00.MD
+++ b/code/web/release_notes/23.11.00.MD
@@ -1,0 +1,19 @@
+## Aspen LiDA Updates
+- 
+
+## Aspen Discovery Updates
+//mark
+
+//kirstien
+
+//kodi
+
+//alexander
+
+//jacob
+
+//lucas
+
+
+## This release includes code contributions from
+- ByWater Solutions


### PR DESCRIPTION
Minor changes made to the CSS to ensure that the availability buttons remain consistent with one another in size when viewing on smaller devices. 

Test Plan: (Carry out a search that produces multiple results).

Set browser to responsive viewing or choose a mobile browsing device. As the screen gets smaller, note that the "Entire Collection" tab becomes taller than the "Centerville" and "Available Now" tabs at some screen widths.

Apply Patch
Repeat the above, all three availability tabs should now be consistent in size as the screen is resized. 
