### PR TITLE
Cookie consent user storage

### DIFF
--- a/code/web/index.php
+++ b/code/web/index.php
@@ -135,31 +135,36 @@ $timer->logTime('Loaded display options within interface');
 
 global $active_ip;
 
+
 try {
-	require_once ROOT_DIR . '/sys/Enrichment/GoogleApiSetting.php';
-	$googleSettings = new GoogleApiSetting();
-	if ($googleSettings->find(true)) {
-		$googleAnalyticsId = $googleSettings->googleAnalyticsTrackingId;
-		$googleAnalyticsLinkingId = $googleSettings->googleAnalyticsTrackingId;
-		$interface->assign('googleAnalyticsId', $googleSettings->googleAnalyticsTrackingId);
-		$interface->assign('googleAnalyticsLinkingId', $googleSettings->googleAnalyticsLinkingId);
-		$interface->assign('googleAnalyticsVersion', empty($googleSettings->googleAnalyticsVersion) ? 'v3' : $googleSettings->googleAnalyticsVersion);
-		$linkedProperties = '';
-		if (!empty($googleSettings->googleAnalyticsLinkedProperties)) {
-			$linkedPropertyArray = preg_split('~\\r\\n|\\r|\\n~', $googleSettings->googleAnalyticsLinkedProperties);
-			foreach ($linkedPropertyArray as $linkedProperty) {
-				if (strlen($linkedProperties) > 0) {
-					$linkedProperties .= ', ';
+	$cookie = json_decode(urldecode($_COOKIE["cookieConsent"]), true);
+	$analyticsPref = $cookie['Analytics'];
+	if (empty($library->cookieStorageConsent) || (!empty($library->cookieStorageConsent) && $analyticsPref == 1)){
+		require_once ROOT_DIR . '/sys/Enrichment/GoogleApiSetting.php';
+		$googleSettings = new GoogleApiSetting();
+		if ($googleSettings->find(true)) {
+			$googleAnalyticsId = $googleSettings->googleAnalyticsTrackingId;
+			$googleAnalyticsLinkingId = $googleSettings->googleAnalyticsTrackingId;
+			$interface->assign('googleAnalyticsId', $googleSettings->googleAnalyticsTrackingId);
+			$interface->assign('googleAnalyticsLinkingId', $googleSettings->googleAnalyticsLinkingId);
+			$interface->assign('googleAnalyticsVersion', empty($googleSettings->googleAnalyticsVersion) ? 'v3' : $googleSettings->googleAnalyticsVersion);
+			$linkedProperties = '';
+			if (!empty($googleSettings->googleAnalyticsLinkedProperties)) {
+				$linkedPropertyArray = preg_split('~\\r\\n|\\r|\\n~', $googleSettings->googleAnalyticsLinkedProperties);
+				foreach ($linkedPropertyArray as $linkedProperty) {
+					if (strlen($linkedProperties) > 0) {
+						$linkedProperties .= ', ';
+					}
+					$linkedProperties .= "'$linkedProperty'";
 				}
-				$linkedProperties .= "'$linkedProperty'";
 			}
-		}
-		$interface->assign('googleAnalyticsLinkedProperties', $linkedProperties);
-		if ($googleAnalyticsId) {
-			$googleAnalyticsDomainName = !empty($googleSettings->googleAnalyticsDomainName) ? $googleSettings->googleAnalyticsDomainName : strstr($_SERVER['SERVER_NAME'], '.');
-			// check for a config setting, use that if found, otherwise grab domain name  but remove the first subdomain
-			$interface->assign('googleAnalyticsDomainName', $googleAnalyticsDomainName);
-		}
+			$interface->assign('googleAnalyticsLinkedProperties', $linkedProperties);
+			if ($googleAnalyticsId) {
+				$googleAnalyticsDomainName = !empty($googleSettings->googleAnalyticsDomainName) ? $googleSettings->googleAnalyticsDomainName : strstr($_SERVER['SERVER_NAME'], '.');
+				// check for a config setting, use that if found, otherwise grab domain name  but remove the first subdomain
+				$interface->assign('googleAnalyticsDomainName', $googleAnalyticsDomainName);
+			}
+		}	
 	}
 } catch (Exception $e) {
 	//This happens when Google analytics settings aren't setup yet

--- a/code/web/index.php
+++ b/code/web/index.php
@@ -259,6 +259,19 @@ $interface->assign('cookieStorageConsent', false);
 $interface->assign('cookieStorageConsentHTML', '');
 if (!empty($library) && !empty($library->cookieStorageConsent)) {
 	try {
+		$userObj = UserAccount::getActiveUserObj();
+		//If the user is logged in and has set their cookie preferences (and has no preferences in db yet) prior to logging in, save these preferences in DB
+		if (isset($_COOKIE["cookieConsent"]) && UserAccount::isLoggedIn() && $userObj->userCookiePreferenceEssential != 1) {
+			$cookie = json_decode(urldecode($_COOKIE["cookieConsent"]), true);
+			if (!empty($_COOKIE["cookieConsent"])) {
+			$analyticsPref = $cookie['Analytics'];
+			$userObj->userCookiePreferenceEssential = 1;
+			$userObj->userCookiePreferenceAnalytics = $analyticsPref;
+			$userObj->update();
+			}
+		}
+		//Assign variables to smarty interface
+		$interface->assign('profile', $userObj);
 		$interface->assign('cookieStorageConsent', true);
 		$interface->assign('cookieStorageConsentHTML', $library->cookiePolicyHTML);
 	} catch (Exception $e) {

--- a/code/web/index.php
+++ b/code/web/index.php
@@ -259,7 +259,7 @@ $interface->assign('cookieStorageConsent', false);
 $interface->assign('cookieStorageConsentHTML', '');
 if (!empty($library) && !empty($library->cookieStorageConsent)) {
 	try {
-		// $interface->assign('cookieStorageConsent', true);
+		$interface->assign('cookieStorageConsent', true);
 		$interface->assign('cookieStorageConsentHTML', $library->cookiePolicyHTML);
 	} catch (Exception $e) {
 		//Not yet setup. Ignore

--- a/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/myPreferences.tpl
@@ -195,6 +195,23 @@
 						</div>
 					{/if}
 
+					{if !empty($loggedIn) && $profile->userCookiePreferenceEssential == 1 && !empty($cookieConsentEnabled)}
+						<div class="form-group #propertyRow">
+						<strong class="control-label">{translate text="Cookies to allow" isPublicFacing=true}:</strong>&nbsp;
+						<div style='padding:0.5em 1em;'>
+							<div class="form-group propertyRow">
+								<label for='userCookieEssential' class="control-label">{translate text="Essential" isPublicFacing=true}</label>&nbsp;
+								<input disabled="disabled" type="checkbox" class="form-control" name="userCookieEssential" id="userCookieEssential" {if $profile->userCookiePreferenceEssential==1}checked='checked'{/if} data-switch="">
+
+							</div>
+							<div class="form-group propertyRow">
+								<label for='userCookieAnalytics' class="control-label">{translate text="Analytics" isPublicFacing=true}</label>&nbsp;
+								<input type="checkbox" class="form-control" name="userCookieAnalytics" id="userCookieAnalytics" {if $profile->userCookiePreferenceAnalytics==1}checked='checked'{/if} data-switch="">
+
+							</div>
+						</div>
+					{/if}
+
 					{if empty($offline) && $edit == true}
 						<div class="form-group propertyRow">
 							<button type="submit" name="updateMyPreferences" class="btn btn-sm btn-primary">{translate text="Update My Preferences" isPublicFacing=true}</button>

--- a/code/web/interface/themes/responsive/cookie-consent.tpl
+++ b/code/web/interface/themes/responsive/cookie-consent.tpl
@@ -1,13 +1,21 @@
-{if empty($smarty.cookies.cookieConsent)}
+{if $loggedIn && $profile->userCookiePreferenceEssential == 1}
+    <script>
+        cookieValues = {
+                    Essential: {$profile->userCookiePreferenceEssential},
+                    Analytics: {$profile->userCookiePreferenceAnalytics},
+                };
+        AspenDiscovery.CookieConsent.fetchUserCookie(encodeURIComponent(JSON.stringify(cookieValues)));
+    </script>
+{elseif empty($smarty.cookies.cookieConsent)}
     <div class="stripPopup">
         <div class="cookieContainer">
             <div class="contentWrap">
                 <span>{translate text="We use cookies on this site to enhance your user experience." isPublicFacing=true}</span>
-                <abbr>{translate text="By clicking any link on this website, you are giving us consent to set and store cookies." isPublicFacing=true}<abbr>
+                <abbr>{translate text="For details about the cookies and technologies we use, see our <abbr style='display:inline-block'><u style='cursor:pointer;' onclick='AspenDiscovery.CookieConsent.cookieDisagree();'>cookie policy</u></abbr>. <br/> Using this banner will set a cookie on your device to remember your preferences." isPublicFacing=true}<abbr>
             </div>
             <div class="btnWrap">
-                <a onclick="AspenDiscovery.CookieConsent.cookieAgree();" href="#" id="consentAgree" class="button">{translate text="Yes, I agree" isPublicFacing=true}</a>
-                <a onclick="AspenDiscovery.CookieConsent.cookieDisagree();" href="#" id="consentDisagree" class="button">{translate text="No, I want to find out more" isPublicFacing=true}</a>
+                <a onclick="AspenDiscovery.CookieConsent.cookieAgree('all');" href="#" id="consentAgree" class="button">{translate text="Accept all cookies" isPublicFacing=true}</a>
+                <a onclick="AspenDiscovery.CookieConsent.cookieAgree('essential');" href="#" id="consentDisagree" class="button">{translate text="Only accept essential cookies" isPublicFacing=true}</a>
             </div>
         </div>
     </div>

--- a/code/web/interface/themes/responsive/css/cookie-consent.less
+++ b/code/web/interface/themes/responsive/css/cookie-consent.less
@@ -11,7 +11,7 @@
 
     .btnWrap{
         a.button{
-            width:188px;
+            width:193px;
             padding: 12px 10px;
             font-size: 12px;
             font-weight: 700;

--- a/code/web/interface/themes/responsive/css/main.css
+++ b/code/web/interface/themes/responsive/css/main.css
@@ -10931,7 +10931,7 @@ input[type="radio"][name="colorScheme"]:checked + label::after {
   font-family: sans-serif;
 }
 .stripPopup .btnWrap a.button {
-  width: 188px;
+  width: 193px;
   padding: 12px 10px;
   font-size: 12px;
   font-weight: 700;

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -15100,10 +15100,18 @@ class TabsSwitcher {
 }
 AspenDiscovery.CookieConsent = (function() {
     return {
-        cookieAgree: function() {
-            console.log('cookieAgree');
-            var aDate = new Date();
-            aDate.setMonth(aDate.getMonth() + 3);
+        cookieAgree: function(props) {
+            if (props == 'all') {
+                var cookieString = {
+                    Essential:1,
+                    Analytics:1,
+                };
+            } else if (props == 'essential') {
+                var cookieString = {
+                    Essential:1,
+                    Analytics:0,
+                };
+            }
             $('.stripPopup').hide();
             $('.modal').modal('hide');
             //set cookie and update db (if logged in) with AJAX
@@ -15132,10 +15140,12 @@ AspenDiscovery.CookieConsent = (function() {
 			return false;
         },
         cookieDisagree: function() {
-            console.log('cookieDisagree');  
-            $('.stripPopup').hide();
-            AspenDiscovery.showMessageWithButtons("Cookie Policy", Globals.cookiePolicyHTML,'<button onclick=\"AspenDiscovery.CookieConsent.cookieAgree\(\)\;\" class=\'tool btn btn-primary\' id=\'modalConsentAgree\' >Accept essential cookies</button>', true);
+            AspenDiscovery.showMessage("Cookie Policy", Globals.cookiePolicyHTML);
             return;
-        }
+        },
+        fetchUserCookie: function(Values) {
+            document.cookie = 'cookieConsent' + '=' + encodeURIComponent(Values) + ';  path=/';
+            return;
+        },
     }
 }(AspenDiscovery.CookieConsent));

--- a/code/web/interface/themes/responsive/js/aspen.js
+++ b/code/web/interface/themes/responsive/js/aspen.js
@@ -15106,8 +15106,30 @@ AspenDiscovery.CookieConsent = (function() {
             aDate.setMonth(aDate.getMonth() + 3);
             $('.stripPopup').hide();
             $('.modal').modal('hide');
-            document.cookie = 'cookieConsent' + '=' + encodeURIComponent(aDate) + '; expires=' + aDate.toUTCString() + '; path=/';
-            return;
+            //set cookie and update db (if logged in) with AJAX
+			var url = Globals.path + "/AJAX/JSON";
+			var params =  {
+				method : 'saveCookiePreference',
+                cookieEssential: cookieString['Essential'],
+                cookieAnalytics: cookieString['Analytics'],
+			};
+			$.getJSON(url, params,
+				function(data) {
+					if (data.success) {
+						if (data.message.length > 0){
+							//User was logged in, show a message about how to update
+							AspenDiscovery.showMessage('Success', data.message, true, true);
+						}else{
+							//Refresh the page
+							// noinspection SillyAssignmentJS
+							window.location.href = window.location.href;
+						}
+					} else {
+						AspenDiscovery.showMessage("Error", data.message);
+					}
+				}
+			).fail(AspenDiscovery.ajaxFail);
+			return false;
         },
         cookieDisagree: function() {
             console.log('cookieDisagree');  

--- a/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
+++ b/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
@@ -6,8 +6,30 @@ AspenDiscovery.CookieConsent = (function() {
             aDate.setMonth(aDate.getMonth() + 3);
             $('.stripPopup').hide();
             $('.modal').modal('hide');
-            document.cookie = 'cookieConsent' + '=' + encodeURIComponent(aDate) + '; expires=' + aDate.toUTCString() + '; path=/';
-            return;
+            //set cookie and update db (if logged in) with AJAX
+			var url = Globals.path + "/AJAX/JSON";
+			var params =  {
+				method : 'saveCookiePreference',
+                cookieEssential: cookieString['Essential'],
+                cookieAnalytics: cookieString['Analytics'],
+			};
+			$.getJSON(url, params,
+				function(data) {
+					if (data.success) {
+						if (data.message.length > 0){
+							//User was logged in, show a message about how to update
+							AspenDiscovery.showMessage('Success', data.message, true, true);
+						}else{
+							//Refresh the page
+							// noinspection SillyAssignmentJS
+							window.location.href = window.location.href;
+						}
+					} else {
+						AspenDiscovery.showMessage("Error", data.message);
+					}
+				}
+			).fail(AspenDiscovery.ajaxFail);
+			return false;
         },
         cookieDisagree: function() {
             console.log('cookieDisagree');  

--- a/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
+++ b/code/web/interface/themes/responsive/js/aspen/cookieConsent.js
@@ -1,9 +1,17 @@
 AspenDiscovery.CookieConsent = (function() {
     return {
-        cookieAgree: function() {
-            console.log('cookieAgree');
-            var aDate = new Date();
-            aDate.setMonth(aDate.getMonth() + 3);
+        cookieAgree: function(props) {
+            if (props == 'all') {
+                var cookieString = {
+                    Essential:1,
+                    Analytics:1,
+                };
+            } else if (props == 'essential') {
+                var cookieString = {
+                    Essential:1,
+                    Analytics:0,
+                };
+            }
             $('.stripPopup').hide();
             $('.modal').modal('hide');
             //set cookie and update db (if logged in) with AJAX
@@ -32,10 +40,13 @@ AspenDiscovery.CookieConsent = (function() {
 			return false;
         },
         cookieDisagree: function() {
-            console.log('cookieDisagree');  
-            $('.stripPopup').hide();
-            AspenDiscovery.showMessageWithButtons("Cookie Policy", Globals.cookiePolicyHTML,'<button onclick=\"AspenDiscovery.CookieConsent.cookieAgree\(\)\;\" class=\'tool btn btn-primary\' id=\'modalConsentAgree\' >Accept essential cookies</button>', true);
+            AspenDiscovery.showMessage("Cookie Policy", Globals.cookiePolicyHTML);
             return;
-        }
+        },
+        fetchUserCookie: function(Values) {
+            document.cookie = 'cookieConsent' + '=' + encodeURIComponent(Values) + ';  path=/';
+            return;
+        },
     }
 }(AspenDiscovery.CookieConsent));
+

--- a/code/web/services/AJAX/JSON.php
+++ b/code/web/services/AJAX/JSON.php
@@ -22,6 +22,7 @@ class AJAX_JSON extends Action {
 				'getTranslationForm',
 				'saveTranslation',
 				'saveLanguagePreference',
+				'saveCookiePreference',
 				'deleteTranslationTerm',
 				'getDisplaySettingsForm',
 				'updateDisplaySettings'
@@ -87,6 +88,32 @@ class AJAX_JSON extends Action {
 			return [
 				'success' => true,
 				'message' => '',
+			];
+		}
+	}
+
+	/** @noinspeciton PhpUnused */
+	function saveCookiePreference(){
+		if (UserAccount::isLoggedIn()) {
+			//update user object with cookie preference choice from cookieConsent banner
+			$userObj = UserAccount::getActiveUserObj();
+			$userObj->userCookiePreferenceEssential = $_REQUEST['cookieEssential'];
+			$userObj->userCookiePreferenceAnalytics = $_REQUEST['cookieAnalytics'];
+			$userObj->update(); //update user object to DB
+			return[
+				'success' => true,
+				'message' => 'Your preferences were updated.  You can make changes to these preferences within your account settings.',
+			];
+		} else {
+			//if not logged in, still set the cookieConsent cookie with user's choice
+			$userCookiePost = [
+				'Essential' => 1, //Essential cookies cannot be disabled
+				'Analytics' => $_REQUEST['cookieAnalytics'],
+				];
+			setcookie('cookieConsent', json_encode($userCookiePost), 0, '/');
+			return [
+				'success' => true,
+				'message' => ''//does this require a messge?,
 			];
 		}
 	}

--- a/code/web/services/MyAccount/MyPreferences.php
+++ b/code/web/services/MyAccount/MyPreferences.php
@@ -111,6 +111,7 @@ class MyAccount_MyPreferences extends MyAccount {
 				$showEdsPreferences = true;
 			}
 			$interface->assign('showEdsPreferences', $showEdsPreferences);
+			$interface->assign('cookieConsentEnabled', $library->cookieStorageConsent);
 
 			if ($showAlternateLibraryOptionsInProfile) {
 				//Get the list of locations for display in the user interface.

--- a/code/web/sys/Account/User.php
+++ b/code/web/sys/Account/User.php
@@ -46,6 +46,8 @@ class User extends DataObject {
 	public $oAuthAccessToken;
 	public $oAuthRefreshToken;
 	public $isLoggedInViaSSO;
+	public $userCookiePreferenceEssential;
+	public $userCookiePreferenceAnalytics;
 
 	public $holdInfoLastLoaded;
 	public $checkoutInfoLastLoaded;
@@ -1151,6 +1153,13 @@ class User extends DataObject {
 					$this->__set('myLocation2Id', $_POST['myLocation2']);
 				}
 			}
+		}
+
+		//update DB values with current checkbox status in myPreferences
+		if (isset ($_COOKIE['cookieConsent'])) {
+			setcookie("cookieConsent", "", time() - 3600, "/"); //remove old cookie so new one can be generated on next page load
+			$this->__set('userCookiePreferenceEssential', 1);
+			$this->__set('userCookiePreferenceAnalytics', (isset($_POST['userCookieAnalytics']) && $_POST['userCookieAnalytics'] == 'on') ? 1 : 0);
 		}
 
 		$this->__set('noPromptForUserReviews', (isset($_POST['noPromptForUserReviews']) && $_POST['noPromptForUserReviews'] == 'on') ? 1 : 0);

--- a/code/web/sys/DBMaintenance/version_updates/23.11.00.php
+++ b/code/web/sys/DBMaintenance/version_updates/23.11.00.php
@@ -17,6 +17,22 @@ function getUpdates23_11_00(): array {
 			],
 		],
 		//Jacob - PTFS
+		'user_cookie_preference_essential' => [
+			'title' => 'Add user editable cookie preferences for essential cookies',
+			'description' => 'Allow essential cookie preferences to be saved on a per user basis',
+			'continueOnError' => true,
+			'sql' => [
+				"ALTER TABLE user add column userCookiePreferenceEssential INT(1) DEFAULT 0",
+			],
+		],//user_cookie_preference_essential
+		'user_cookie_preference_analytics' => [
+			'title' => 'Add user editable cookie preferences for analytics cookies',
+			'description' => 'Allow analytics cookie preferences to be saved on a per user basis',
+			'continueOnError' => true,
+			'sql' => [
+				"ALTER TABLE user add column userCookiePreferenceAnalytics INT(1) DEFAULT 0",
+			],
+		],//user_cookie_preference_analytics
 		//other
     ];
 }

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -3267,8 +3267,8 @@ class Library extends DataObject {
 					'cookieStorageConsent' => [
 						'property' => 'cookieStorageConsent',
 						'type' => 'checkbox',
-						'label' => 'Require Cookie Storage Consent (FUNCTIONALITY CURRENTLY DISABLED)',
-						'description' => 'Require users to consent to cookie storage before using the catalog (THIS IS CURRENTLY DISABLED FUNCTIONALITY AND ENABLING THIS OPTION WILL NOT ENABLE COOKIE CONSENT REQUIREMENTS)',
+						'label' => 'Require Cookie Storage Consent',
+						'description' => 'Require users to consent to cookie storage before using the catalog',
 						'default' => false,
 					],
 					'cookiePolicyHTML' => [


### PR DESCRIPTION
This PR changes the cookie consent cookie to a session based cookie, allows storage on a per user basis and allows the preferences to be amended in myPreferences. Also redesigns the cookie consent banner slightly to be more user friendly 

This WILL need a small patch to go alongside to disable google analytics when analytics cookies have not been allowed but would like your input on where you would like it disabled  (I was thinking index.php - around line 138) let me know if you have a preference. Should just be an if statement so literally 30 seconds worth of work.

Test plan:
Enable cookie consent in library settings
Allow cookies,
Check that cookies are set,
delete cookie and check cookie is reapplied from DB on refresh,
delete cookie from both browser and set the cookies to 0 in the user table of the DB to re-enable the banner on refresh
check that the option for "only allow essential cookies" keeps analytics set to 0 in the DB
set cookies preferences to 0 and test that if you set your preferences and log in after, your preferences are saved in the db.
Check that you can amend your preferences in the myPreferences page (you should not be able to modify essential cookies preferences as these are essential)



I also still have the DB changes in 23.10.00 at the moment as there does not seem to be a file for 23.11.00 yet. If you need it moved, please let me know.

