### PR TITLE
Boundless Errors

### DIFF
--- a/code/axis_360_export/src/com/turning_leaf_technogies/axis360/Axis360Extractor.java
+++ b/code/axis_360_export/src/com/turning_leaf_technogies/axis360/Axis360Extractor.java
@@ -533,7 +533,7 @@ public class Axis360Extractor {
 			}
 			numTries++;
 		}
-		if (numTries == 3 && !availabilityResponse.callSucceeded) {
+		if (numTries == 3 && !availabilityResponse.callSucceeded && !availabilityResponse.titleIsUnavailable) {
 			logEntry.incErrors("Did not get a successful API response after 3 tries for " + availabilityUrl);
 		}
 		return availabilityResponse;

--- a/code/web/release_notes/23.12.00.MD
+++ b/code/web/release_notes/23.12.00.MD
@@ -7,6 +7,8 @@
 //kirstien ByWater
 
 //kodi ByWater
+### Boundless Updates
+- Fix issue where unavailable titles were throwing errors during indexing. (Ticket 121359)
 
 //alexander PTFSE
 


### PR DESCRIPTION
Fix error "Did not get a successful API response ..." for unavailable Boundless titles
Updated release notes