### PR TITLE
Use OPAC renewals with Evergreen

### DIFF
--- a/code/web/Drivers/Evergreen.php
+++ b/code/web/Drivers/Evergreen.php
@@ -205,11 +205,7 @@ class Evergreen extends AbstractIlsDriver {
 			$namedParams = [
 				'patron_id' => (int)$patron->unique_ils_id,
 				"copy_id" => $itemId,
-//				'id' => $itemId,
-//				'circ' => [
-//					'copy_id' => $itemId
-//				]
-				//"opac_renewal" => 1,
+				"opac_renewal" => 1,
 			];
 			$request .= '&param=' . json_encode($namedParams);
 


### PR DESCRIPTION
Evergreen has settings and rules for handling patron renewals via the OPAC. If we pass the opac_renewal option to Evergreen, then Aspen will act like Evergreen when renewing on behalf of a patron.

This commit also removes four extraneous lines that are commented out in the Evergreen renewal code.