### PR TITLE
Fixed user name property

### DIFF
--- a/code/web/release_notes/23.12.00.MD
+++ b/code/web/release_notes/23.12.00.MD
@@ -76,6 +76,8 @@
 
 ### Quick Poll Results Updates
 - An option has been added to allow users to decide whether to show results to patrons who are not logged in, as well as to choose whether to show graphs, tables or both.
+- Now,if the name field is completed for unathenticated users, it will be completed on the form instead a blank space.
+- If an authenticated user fills in the name field, then the submission form will have the name that the user entered in the form instead of the username.
 
 ### Other
 - Create initial Docker configuration so Aspen can be run within a container.

--- a/code/web/sys/WebBuilder/QuickPollSubmission.php
+++ b/code/web/sys/WebBuilder/QuickPollSubmission.php
@@ -86,10 +86,12 @@ class QuickPollSubmission extends DataObject {
 			$user = new User();
 			$user->id = $this->userId;
 			if ($user->find(true)) {
-				$this->_data[$name] = empty($user->displayName) ? ($user->firstname . ' ' . $user->lastname) : $user->displayName;
+				$this->_data[$name] = $this->name ?? $user->displayName;
+			} else {
+				$this->_data[$name] = $this->name;
 			}
 			$user->__destruct();
-			return $this->_data[$name] ?? null;
+			return $this->_data[$name];
 		} elseif ($name == 'selectedOptions') {
 			if ($this->_selectedOptions == null) {
 				$this->_selectedOptions = [];


### PR DESCRIPTION
- Now,if the name field is completed for unathenticated users, it will be completed on the form instead a blank space.
- If an authenticated user fill the name field,then the form submission will have the name the user entered in the form instead the user name.