### PR TITLE
email confirmation symphony self reg

### DIFF
--- a/code/web/Drivers/SirsiDynixROA.php
+++ b/code/web/Drivers/SirsiDynixROA.php
@@ -3435,35 +3435,27 @@ class SirsiDynixROA extends HorizonAPI {
 						'label' => 'Receive notices via text',
 						'onchange' => 'AspenDiscovery.Account.updateSelfRegistrationFields()',
 					];
-				} /*elseif ($customField->symphonyName == 'city_state') {
-					$fields['City'] = [
-						'property' => 'city',
+				} elseif ($customField->symphonyName == "email"){
+					$fields[$customField->symphonyName] = [
+						'property' => $customField->symphonyName,
 						'type' => $customField->fieldType,
-						'label' => 'City',
+						'label' => $customField->displayName,
+						'maxLength' => 128,
 						'required' => $customField->required,
-						'note' => $customField->note
+						'note' => $customField->note,
+						'autocomplete' => false,
 					];
-					if (!empty($library->validSelfRegistrationStates)){
-						$validStates = explode('|', $library->validSelfRegistrationStates);
-						$validStates = array_combine($validStates, $validStates);
-						$fields['State'] = [
-							'property' => 'state',
-							'type' => 'enum',
-							'values' => $validStates,
-							'label' => 'State',
+					if ($customField->required){
+						$fields['email2'] = [
+							'property' => 'email2',
+							'type' => 'email',
+							'label' => 'Confirm Email',
+							'maxLength' => 128,
 							'required' => $customField->required,
-							'note' => $customField->note,
-						];
-					} else {
-						$fields['State'] = [
-							'property' => 'state',
-							'type' => $customField->fieldType,
-							'label' => 'State',
-							'required' => $customField->required,
-							'note' => $customField->note
+							'autocomplete' => false,
 						];
 					}
-				}*/ elseif ($customField->symphonyName == 'zip' && !empty($library->validSelfRegistrationZipCodes)) {
+				} elseif ($customField->symphonyName == 'zip' && !empty($library->validSelfRegistrationZipCodes)) {
 					$fields[$customField->symphonyName] = [
 						'property' => $customField->symphonyName,
 						'type' => $customField->fieldType,

--- a/code/web/release_notes/23.12.00.MD
+++ b/code/web/release_notes/23.12.00.MD
@@ -88,6 +88,7 @@
 - Fix Access Online button redirects when multiple variations are present on a record (Ticket 122445)
 - Update OverDrive to Libby or a custom defined product name
 - Fix error when updating themes with certain locked values
+- Add email confirmation to custom Symphony self registration forms if email is required (Ticket 123482)
 
 //alexander PTFSE
 #### Display Updates


### PR DESCRIPTION
Adds same functionality from original symphony self registration to custom self registration forms where, if email is required, a second "confirm email" field will appear 
Updated release notes