### PR TITLE
ensure that Square is passed a string for idempotency_key

### DIFF
--- a/code/web/services/MyAccount/AJAX.php
+++ b/code/web/services/MyAccount/AJAX.php
@@ -4859,7 +4859,7 @@ class MyAccount_AJAX extends JSON_Action {
 				$paymentId = $payment->id;
 				$paymentAmount = $payment->totalPaid;
 				$body = [
-					'idempotency_key' => $paymentId,
+					'idempotency_key' => strval($paymentId), // Square needs this to be a string, so guarantee it
 					'amount_money' => [
 						'amount' => (int)round($payment->totalPaid * 100),
 						'currency' => 'USD'


### PR DESCRIPTION
Depending on PHP and MySQL driver versions, PHP is increasingly more likely to return numeric columns as PHP integers or floats.

For example, PHP 8.1+ will now do this for emulated prepared statements.

Since Square requires that the idempotency_key be a JSON string, but Aspen uses the numeric user_payments ID for the purpose, this patch ensures that it gets cast to a string.

Concretely, this patch fixes a bug where payments can fail to be created in Square with the following error (as found in Square's API logs):

```
{
  "errors": [
    {
      "code": "EXPECTED_STRING",
      "detail": "Expected a string value (line 1, character 20)",
      "field": "idempotency_key",
      "category": "INVALID_REQUEST_ERROR"
    }
  ]
}
```