### PR TITLE
Fallback to User Phone When Placing Holds in Evergreen

### DIFF
--- a/code/web/Drivers/Evergreen.php
+++ b/code/web/Drivers/Evergreen.php
@@ -397,6 +397,8 @@ class Evergreen extends AbstractIlsDriver {
 			if (isset($_REQUEST['phoneNotification']) && $_REQUEST['phoneNotification'] == 'on') {
 				if (isset($_REQUEST['phoneNumber']) && strlen($_REQUEST['phoneNumber']) > 0) {
 					$namedParams['phone_notify'] = $_REQUEST['phoneNumber'];
+				} elseif (isset($patron->phone) && strlen($patron->phone) > 0) {
+					$namedParams['phone_notify'] = $patron->phone;
 				}
 			}
 			if (isset($_REQUEST['smsNotification']) && $_REQUEST['smsNotification'] == 'on') {
@@ -1049,6 +1051,8 @@ class Evergreen extends AbstractIlsDriver {
 			if (isset($_REQUEST['phoneNotification']) && $_REQUEST['phoneNotification'] == 'on') {
 				if (isset($_REQUEST['phoneNumber']) && strlen($_REQUEST['phoneNumber']) > 0) {
 					$namedParams['phone_notify'] = $_REQUEST['phoneNumber'];
+				} elseif (isset($patron->phone) && strlen($patron->phone) > 0) {
+					$namedParams['phone_notify'] = $patron->phone;
 				}
 			}
 			if (isset($_REQUEST['smsNotification']) && $_REQUEST['smsNotification'] == 'on') {

--- a/code/web/interface/themes/responsive/MyAccount/evergreenHoldNotificationPreferences.tpl
+++ b/code/web/interface/themes/responsive/MyAccount/evergreenHoldNotificationPreferences.tpl
@@ -33,7 +33,7 @@
 		{/if}
 		<div>
 			<label for="phoneNotification">
-				<input type="checkbox" id="phoneNotification" name="phoneNotification" {if !empty($opac_default_phone) && in_array('phone', $opac_hold_notify)}checked{/if}> {translate text="Send phone notification" isPublicFacing=true}
+				<input type="checkbox" id="phoneNotification" name="phoneNotification" {if in_array('phone', $opac_hold_notify)}checked{/if}> {translate text="Send phone notification" isPublicFacing=true}
 			</label>
 			<div class="form-group">
 				<label class="control-label" for="phoneNumber">{translate text="Phone Number" isPublicFacing=true}</label>

--- a/code/web/interface/themes/responsive/Record/evergreenHoldNotifications.tpl
+++ b/code/web/interface/themes/responsive/Record/evergreenHoldNotifications.tpl
@@ -11,7 +11,7 @@
 	{/if}
 	<div>
 		<label for="phoneNotification">
-			<input type="checkbox" id="phoneNotification" name="phoneNotification" {if !empty($opac_default_phone) && in_array('phone', $opac_hold_notify)}checked{/if}> {translate text="Yes, by phone" isPublicFacing=true}
+			<input type="checkbox" id="phoneNotification" name="phoneNotification" {if in_array('phone', $opac_hold_notify)}checked{/if}> {translate text="Yes, by phone" isPublicFacing=true}
 		</label>
 		<div class="form-group">
 			<label class="control-label" for="phoneNumber">{translate text="Phone Number" isPublicFacing=true}</label>

--- a/code/web/release_notes/23.12.00.MD
+++ b/code/web/release_notes/23.12.00.MD
@@ -50,6 +50,7 @@
 - Add a configuration option to Indexing Profiles for the maximum number of retries after a failed bib fetch from Evergreen. 
 - Add a configuration option for a number of milliseconds to pause execution after each bib fetched from Evergreen.
 - Add a configuration option for a number of threads to use when fetching bibs from Evergreen.
+- When placing holds and phone_notify is checked and no default notification phone is set, it will fall back to day phone, evening phone, or other phone if they exist.
 
 <div markdown="1" class="settings">
 

--- a/code/web/release_notes/23.12.00.MD
+++ b/code/web/release_notes/23.12.00.MD
@@ -50,7 +50,6 @@
 - Add a configuration option to Indexing Profiles for the maximum number of retries after a failed bib fetch from Evergreen. 
 - Add a configuration option for a number of milliseconds to pause execution after each bib fetched from Evergreen.
 - Add a configuration option for a number of threads to use when fetching bibs from Evergreen.
-- When placing holds and phone_notify is checked and no default notification phone is set, it will fall back to day phone, evening phone, or other phone if they exist.
 
 <div markdown="1" class="settings">
 

--- a/code/web/release_notes/24.01.00.MD
+++ b/code/web/release_notes/24.01.00.MD
@@ -24,6 +24,7 @@
 ### API Updates
 - Added getLibraryLinks to System API to return a list of menu items for the library.
 
+// jboyer - Equinox Open Library Initiative
 ### Evergreen Updates
 - When placing holds and phone_notify is checked and no default notification phone is set, it will fall back to day phone, evening phone, or other phone if they exist.
 

--- a/code/web/release_notes/24.01.00.MD
+++ b/code/web/release_notes/24.01.00.MD
@@ -24,6 +24,9 @@
 ### API Updates
 - Added getLibraryLinks to System API to return a list of menu items for the library.
 
+### Evergreen Updates
+- When placing holds and phone_notify is checked and no default notification phone is set, it will fall back to day phone, evening phone, or other phone if they exist.
+
 ### Library System Updates
 - For menu items, added the option "Show On" to determine where the link should display.
 
@@ -45,3 +48,4 @@
 
 ## This release includes code contributions from
 - ByWater Solutions
+- Equinox Open Library Initiative


### PR DESCRIPTION
If a user has phone notifications enabled but no default phone notification number set, fallback to the day / evening / other phone on their account. This is how the Evergreen OPAC works; the default notification phone number will be used if present, but is not required if another phone number is available on the account.