### PR TITLE
Changes to SolrHost and SolrPort variables

### DIFF
--- a/code/reindexer/src/com/turning_leaf_technologies/reindexer/GroupedReindexMain.java
+++ b/code/reindexer/src/com/turning_leaf_technologies/reindexer/GroupedReindexMain.java
@@ -191,7 +191,7 @@ public class GroupedReindexMain {
 		configIni = ConfigUtil.loadConfigFile("config.ini", serverName, logger);
 
 		baseLogPath = configIni.get("Site", "baseLogPath");
-		String solrPort = configIni.get("Reindex", "solrPort");
+		String solrPort = configIni.get("Index", "solrPort");
 		if (solrPort == null || solrPort.length() == 0) {
 			logger.error("You must provide the port where the solr index is loaded in the import configuration file");
 			System.exit(1);

--- a/code/reindexer/src/com/turning_leaf_technologies/reindexer/GroupedWorkIndexer.java
+++ b/code/reindexer/src/com/turning_leaf_technologies/reindexer/GroupedWorkIndexer.java
@@ -169,7 +169,8 @@ public class GroupedWorkIndexer {
 		this.clearIndex = clearIndex;
 		this.regroupAllRecords = regroupAllRecords;
 
-		String solrPort = configIni.get("Reindex", "solrPort");
+		String solrHost = configIni.get("Index", "solrHost");
+		String solrPort = configIni.get("Index", "solrPort");
 
 		//Load the last Index time
 		try{
@@ -287,9 +288,9 @@ public class GroupedWorkIndexer {
 
 		ConcurrentUpdateSolrClient.Builder solrBuilder;
 		if (indexVersion == 1) {
-			solrBuilder = new ConcurrentUpdateSolrClient.Builder("http://localhost:" + solrPort + "/solr/grouped_works");
+			solrBuilder = new ConcurrentUpdateSolrClient.Builder("http://" + solrHost + ":" + solrPort + "/solr/grouped_works");
 		}else{
-			solrBuilder = new ConcurrentUpdateSolrClient.Builder("http://localhost:" + solrPort + "/solr/grouped_works_v2");
+			solrBuilder = new ConcurrentUpdateSolrClient.Builder("http://" + solrHost + ":" + solrPort + "/solr/grouped_works_v2");
 		}
 		solrBuilder.withThreadCount(1);
 		solrBuilder.withQueueSize(25);

--- a/sites/template.linux/conf/config.ini
+++ b/sites/template.linux/conf/config.ini
@@ -31,9 +31,9 @@ staffClientUrl       = {staffUrl}
 ; This section requires no changes for most installations
 [Index]
 solrHost        = {solrHost}
+solrPort        = {solrPort}
 url             = http://{solrHost}:{solrPort}/solr
 
 [Reindex]
-solrPort             = {solrPort}
 marcPath             = /data/aspen-discovery/{sitename}/ils/marc
 lexileExportPath     = /data/aspen-discovery/lexileTitles.txt

--- a/sites/template.windows/conf/config.ini
+++ b/sites/template.windows/conf/config.ini
@@ -38,11 +38,12 @@ staffClientUrl       = {staffUrl}
 
 ; This section requires no changes for most installations
 [Index]
+solrHost        = {solrHost}
+solrPort        = {solrPort}
 url             = http://{solrHost}:{solrPort}/solr
 
 
 [Reindex]
-solrPort             = {solrPort}
 marcPath             = c:/data/aspen-discovery/{sitename}/marc
 ;The encoding of the marc file.  Specify MARC8, UTF8, UNIMARC, ISO8859_1, or BESTGUESS
 ;In general, best results will be had if you export the records as UTF8 and specify UTF8 here. 


### PR DESCRIPTION
- Current hardcoded 'localhost' has been replaced to SolrHost variable.
- SolrPort has been moved from Reindex array to Index array in config.ini