### PR TITLE
Respect Proxy Protocol

### DIFF
--- a/code/web/release_notes/24.03.00.MD
+++ b/code/web/release_notes/24.03.00.MD
@@ -44,7 +44,7 @@
 
 // jboyer
 ### Other Updates
-- If Aspen is being served from behind a proxy server and the RemoteIP Apache module is configured, links shown in the UI will match the protocol (http:// or https://) used to reach the proxy. (*JB*)
+- If Aspen is being served from behind a proxy, links shown in the UI will match the protocol (http:// or https://) used to reach the proxy. (*JB*)
 
 // other
 

--- a/code/web/release_notes/24.03.00.MD
+++ b/code/web/release_notes/24.03.00.MD
@@ -42,6 +42,10 @@
 ### Springshare LibCal Updates
 - Fixed issue where location/branch was showing twice for LibCal events instead of the Location and Room (Ticket 127575) (*KL*)
 
+// jboyer
+### Other Updates
+- If Aspen is being served from behind a proxy server and the RemoteIP Apache module is configured, links shown in the UI will match the protocol (http:// or https://) used to reach the proxy. (*JB*)
+
 // other
 
 ## This release includes code contributions from
@@ -49,3 +53,5 @@
     - Kirstien Kroeger (KK)
     - Kodi Lein (KL)
     - Mark Noble (MDN)
+- Equinox Open Library Initiative
+    - Jason Boyer (*JB*)

--- a/code/web/sys/ConfigArray.php
+++ b/code/web/sys/ConfigArray.php
@@ -214,7 +214,7 @@ function readConfig() {
 	// Have to set the instanceName before the transformation of $mainArray['Site']['url'] below.
 
 	if (isset($_SERVER['SERVER_NAME'])) {
-		if (isset($_SERVER['HTTPS'])) {
+		if (isset($_SERVER['HTTPS']) || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == "https")) {
 			$mainArray['Site']['url'] = "https://" . $_SERVER['SERVER_NAME'];
 		} else {
 			$mainArray['Site']['url'] = "http://" . $_SERVER['SERVER_NAME'];

--- a/code/web/sys/Interface.php
+++ b/code/web/sys/Interface.php
@@ -105,7 +105,7 @@ class UInterface extends Smarty {
 		} else {
 			$url = $configArray['Site']['url'];
 		}
-		if (isset($_SERVER['HTTPS'])) {
+		if (isset($_SERVER['HTTPS']) || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == "https")) {
 			$url = "https://" . $url;
 		} else {
 			$url = "http://" . $url;


### PR DESCRIPTION
If Aspen is behind a TLS-terminating proxy we don't want to use http:// when building links, even though $_SERVER['HTTPS'] will be false. The X-Forwarded-Proto header is enabled by default for AWS and Google Cloud load balancers, and is easily enabled if using nginx directly.