### PR TITLE
Fix: Summon facet ampersand error

### DIFF
--- a/code/web/sys/SearchObject/SummonSearcher.php
+++ b/code/web/sys/SearchObject/SummonSearcher.php
@@ -481,22 +481,21 @@ class SearchObject_SummonSearcher extends SearchObject_BaseSearcher{
 
 	//Compile filter options chosen in side facets and add to filter array to be passed in via options array
 	public function getSummonFilters() {
-        $this->filters = array();
-        foreach($this->filterList as $key => $value) {
-            if(is_array($value)) {
-                foreach($value as $val){
-                    $parts = explode(' ', $val);
-                    $result = implode('+', $parts);
-                    $this->filters[] = urlencode($key . ',') . $result . urlencode(',');
-                }
-            } else {
-                $parts = explode(' ', $value);
-                $result = implode('+', $parts);
-                $this->filters = urlencode($key . ',') . $result . urlencode(',');
-            }
-        }
-      return $this->filters;
-    }	
+		$this->filters = array();
+		foreach ($this->filterList as $key => $value) {
+			if (is_array($value)) {
+				foreach ($value as $val) {
+					$encodedValue = urlencode($val); 
+					$this->filters[] = urlencode($key) . ',' . $encodedValue . ','; 
+				}
+			} else {
+				$encodedValue = urlencode($value); 
+				$this->filters[] = urlencode($key) . ',' . $encodedValue . ','; 
+			}
+		}
+		return $this->filters;
+	}
+	
 	
 	/**
 	 * Generate an HMAC hash for authentication


### PR DESCRIPTION
This patch alters the order and concatenation of Summon filters so that Summon filters that contain an ampersand return a result rather than an error.
TEST PLAN:
1) Log into Aspen as admin and ensure that Summon is set up correctly. 
2) Carry out a Summon search (ensuring that the dropdown is set to 'Article and Databases.'
3) Filter your search ensuring any of the facets on the left-hand menu that contain an ampersand ('&').
4) This search will return an error. 
5) Apply the patch and repeat the steps above. The facets that contain ampersands will now return the correct results instead of an error. 