### PR TITLE
chore: Update debian upgrade scripts to match centos

### DIFF
--- a/code/web/release_notes/24.02.04.MD
+++ b/code/web/release_notes/24.02.04.MD
@@ -23,9 +23,13 @@
 
 ### Other Updates
 - Fix Search Tools popup when viewing Aspen on small screens. (Tickets 127740, 127746, 127842) (*MDN*)
+- Update Debian upgrade scripts to match Centos upgrade scripts for upto and including 24.02.04 release (*JOM*)
 
 ## This release includes code contributions from
 - ByWater Solutions
   - Kirstien Kroeger (KK)
   - Kodi Lein (KL)
   - Mark Noble (MDN)
+
+- PTFS-Europe
+  - Jacob O'Mara (JOM)

--- a/install/upgrade_debian_23.09.01.sh
+++ b/install/upgrade_debian_23.09.01.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+if [ -z "$1" ]
+  then
+    echo "Please provide the server name to update as the first argument."
+    exit 1
+fi
+
+echo "Updating cron\n"
+php /usr/local/aspen-discovery/install/updateCron_23_09_01.php $1

--- a/install/upgrade_debian_23.12.00.sh
+++ b/install/upgrade_debian_23.12.00.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+if [ -z "$1" ]
+  then
+    echo "Please provide the server name to update as the first argument."
+    exit 1
+fi
+
+echo "Starting Upgrade 23.12.00.sh for $1"
+
+service mysql stop
+sleep 10
+
+apt-get remove -y mariadb-server
+
+cp mariadb.list /etc/apt/sources.list.d/mariadb.list
+apt-get update
+apt-get -y install mariadb-server
+
+service mysql start
+sleep 10
+
+php /usr/local/aspen-discovery/install/runMariaDbUpgrade_23_12.php $1
+
+apt-get install -y software-properties-common
+add-apt-repository ppa:ondrej/php
+apt-get update
+apt-get install -y php8.3
+
+service apache2 restart
+sleep 10
+
+echo "Finished Upgrade 23.12.00.sh for $1"

--- a/install/upgrade_debian_24.01.00.sh
+++ b/install/upgrade_debian_24.01.00.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+if [ -z "$1" ]
+  then
+    echo "Please provide the server name to update as the first argument."
+    exit 1
+fi
+
+echo "Updating cron\n"
+php /usr/local/aspen-discovery/install/updateCron_24_01.php $1
+
+systemctl enable mariadb

--- a/install/upgrade_debian_24.02.00.sh
+++ b/install/upgrade_debian_24.02.00.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+if [ -z "$1" ]; then
+	echo "Please provide the server name to update as the first argument."
+	exit 1
+fi
+
+apt-get update
+yes | apt-get install -y openjdk-11-jdk
+pkill -9 java
+apt-get -y remove openjdk-8-jdk
+apt-get -y remove openjdk-8-jre-headless
+
+chown -R solr:solr /usr/local/aspen-discovery/sites/default/solr-8.11.2
+
+#Update the startup script to call solr 8 rather than solr 7
+echo "updating startup script to use solr 8"
+sed -i -e "s/7.6.0/8.11.2/g" /usr/local/aspen-discovery/sites/$1/$1.sh
+
+truncate -s0 /var/mail/aspen
+truncate -s0 /var/mail/solr
+truncate -s0 /var/mail/root
+
+cp install/logrotate.conf /etc/logrotate.d/aspen_discovery

--- a/install/upgrade_debian_24.02.03.sh
+++ b/install/upgrade_debian_24.02.03.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+if [ -z "$1" ]
+  then
+    echo "Please provide the server name to update as the first argument."
+    exit 1
+fi
+
+cp /usr/local/aspen-discovery/install/limits.conf /etc/security/limits.conf


### PR DESCRIPTION
This patch adds the new debian upgrade scripts to match the upgrades scripts for centos.