### PR TITLE
Use better method to get user settings for Evergreen

### DIFF
--- a/code/web/Drivers/Evergreen.php
+++ b/code/web/Drivers/Evergreen.php
@@ -1679,11 +1679,12 @@ class Evergreen extends AbstractIlsDriver {
 		if ($insert) {
 			$authToken = $this->getAPIAuthToken($user, true);
 			$this->apiCurlWrapper->addCustomHeaders($headers, false);
-			$request = 'service=open-ils.actor&method=open-ils.actor.settings.retrieve.atomic';
+			$request = 'service=open-ils.actor&method=open-ils.actor.patron.settings.retrieve';
+			$request .= '&param=' . json_encode($authToken);
+			$request .= '&param=' . json_encode($user->unique_ils_id);
 			$request .= '&param=' . json_encode([
 					'opac.default_pickup_location',
 				]);
-			$request .= '&param=' . json_encode($authToken);
 
 			$apiResponse = $this->apiCurlWrapper->curlPostPage($evergreenUrl, $request);
 			if ($this->apiCurlWrapper->getResponseCode() == 200) {


### PR DESCRIPTION
Switch to open-ils.actor.patron.settings.retrieve and always pass the user ID to get the default pickup location for new users.

Using this API instead of open-ils.actor.setting.retrieve.atomic allows us to look up setting for patrons even when masquerading.