### PR TITLE
avoid putting authors into list of translatable terms

### DIFF
--- a/code/web/ResultsAction.php
+++ b/code/web/ResultsAction.php
@@ -2,10 +2,10 @@
 
 
 abstract class ResultsAction extends Action {
-	function getResultsBreadcrumbs($searchType) {
+	function getResultsBreadcrumbs($searchTypeOrTerm, $translateTypeOrTerm = true) {
 		global $interface;
 		$breadcrumbs = [];
-		$breadcrumbs[] = new Breadcrumb(null, $searchType);
+		$breadcrumbs[] = new Breadcrumb(null, $searchTypeOrTerm, $translateTypeOrTerm);
 		$recordCount = $interface->getVariable('recordCount');
 		if (empty($recordCount)) {
 			$resultCountText = translate([

--- a/code/web/release_notes/24.03.00.MD
+++ b/code/web/release_notes/24.03.00.MD
@@ -64,6 +64,7 @@
 
 ### Other Updates
 - If Aspen is being served from behind a proxy, links shown in the UI will match the protocol (http:// or https://) used to reach the proxy. (*JB*)
+- Do not add the author from the breadcrumbs of an author page to the list of translatable terms. (*GMC*)
 
 // other
 
@@ -83,4 +84,5 @@
 - Nashville Public Library
     - James Staub (JStaub)
 - Equinox Open Library Initiative
+    - Galen Charlton (GMC)
     - Jason Boyer (*JB*)

--- a/code/web/services/Author/Home.php
+++ b/code/web/services/Author/Home.php
@@ -297,6 +297,6 @@ class Author_Home extends ResultsAction {
 
 	function getBreadcrumbs(): array {
 		global $interface;
-		return parent::getResultsBreadcrumbs($interface->getVariable('authorName'));
+		return parent::getResultsBreadcrumbs($interface->getVariable('authorName'), false);
 	}
 }


### PR DESCRIPTION
/Author/Home puts the (normalized) author name in the breadcrumbs, reasonably enough. However, the author name was getting added to the list of translatable terms, pooching it out with a bunch of terms that normally should be displayed as is. This patch marks normalized author breadcrumbs as not to be translated.