### PR TITLE
Fixing typos and email addresses

### DIFF
--- a/security.md
+++ b/security.md
@@ -2,14 +2,14 @@
 
 The Aspen Discovery team and community take security bugs in Aspen Discovery seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
 
-To report a security issue, please email security@aspendiscovery.org
+To report a security issue, please email security@bywatersolutions.com.
 
 The Aspen Discovery team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
 
 Report security bugs in third-party modules to the person or team maintaining the module.
-## The Electron Security Notification Process
+## The Aspen Discovery Security Notification Process
 
-For context on Aspen Discovery's security notification process, please see the [community documentation](place where this does or will soon live)
+For context on Aspen Discovery's security notification process, please see the [community documentation](place where this does or will soon live).
 
 ## Learning More About Security
 


### PR DESCRIPTION
Electron -> Aspen Discovery
security@aspendiscovery.org (Doesn't currently exist) -> security@bywatersolutions.com - can be temporary