### PR TITLE
Empty strings are not correctly formatted dates

### DIFF
--- a/code/web/Drivers/Koha.php
+++ b/code/web/Drivers/Koha.php
@@ -3092,7 +3092,7 @@ class Koha extends AbstractIlsDriver
 	function aspenDateToKohaApiDate($date)
 	{
 		if (strlen($date) == 0) {
-			return $date;
+			return NULL;
 		} else {
 			if (strpos($date, '/') !== false){
 				list($month, $day, $year) = explode('/', $date);


### PR DESCRIPTION
Koha's API accepts either:

- null
- RFC 3339 formatted dates

passing an empty string is not an option, as it doesn't match the RFC 3339 format.

This patch just makes the empty string use case pass NULL.

I'm not versed enough in PHP but:

- The DateTime class seems to handle reading/writing RFC3339 formatted date/time strings.
- It is not advisable to manually adjust strings to match date formats
- The software should internally pick a representation format and make sure all inputs are sanitized to comply with it
- Each 'driver' should handle converting those DateTime objects to the needed format depending on the external system's requirement

Best regards