### PR TITLE
Run GitHub actions on all pushes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,6 @@
 name: Publish Docker image to hub.docker.com
 on:
-  push:
-    branches:
-      - dockertest
+  push
 
 jobs:
   push_aspen_to_dockerhub:


### PR DESCRIPTION
We should be running GitHub actions on all pushes. This will let the GitHub Actions build the Docker images which the latest release branch is pushed to Aspen-Discovery/aspen-discovery