### PR TITLE
Only run GitHub Actions for building docker images from Aspen-Discovery/aspen-discovery

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   push_aspen_to_dockerhub:
     name: Push Aspen image to Docker Hub
-    #if: ${{ always() && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref }}
+    if: github.repository == 'Aspen-Discovery/aspen-discovery'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -34,7 +34,7 @@ jobs:
 
   push_aspen_to_quay:
     name: Push Aspen image to Quay.io
-    #if: ${{ always() && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref }}
+    if: github.repository == 'Aspen-Discovery/aspen-discovery'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -64,7 +64,7 @@ jobs:
 
   push_solr_to_dockerhub:
     name: Push Solr image to Docker Hub
-    #if: ${{ always() && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref }}
+    if: github.repository == 'Aspen-Discovery/aspen-discovery'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -93,7 +93,7 @@ jobs:
 
   push_solr_to_quay:
     name: Push Solr image to Quay.io
-    #if: ${{ always() && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref }}
+    if: github.repository == 'Aspen-Discovery/aspen-discovery'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -123,7 +123,7 @@ jobs:
 
   push_tunnel_to_dockerhub:
     name: Push Tunnel image to Docker Hub
-    #if: ${{ always() && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref }}
+    if: github.repository == 'Aspen-Discovery/aspen-discovery'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
@@ -152,7 +152,7 @@ jobs:
 
   push_tunnel_to_quay:
     name: Push Tunnel image to Quay.io
-    #if: ${{ always() && format('refs/heads/{0}', github.event.repository.default_branch) == github.ref }}
+    if: github.repository == 'Aspen-Discovery/aspen-discovery'
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo


### PR DESCRIPTION
Aspen-Discovery/aspen-discovery has been all set up for building and pushing the images. This commit will prevent the actions for running and failing on other clones of the codebase in GitHub.