### PR TITLE
Small Fixes

### DIFF
--- a/code/web/Drivers/Evergreen.php
+++ b/code/web/Drivers/Evergreen.php
@@ -834,6 +834,9 @@ class Evergreen extends AbstractIlsDriver {
 					if (empty($circEntryMapped['source_circ'])) {
 						$modsForCopy = $this->getModsForCopy($circEntryMapped['target_copy']);
 						if ($modsForCopy != null) {
+							if (is_integer($modsForCopy['doc_id'])){
+								$modsForCopy['doc_id'] = strval($modsForCopy['doc_id']);
+							}
 							$curTitle = [];
 							$curTitle['id'] = $modsForCopy['doc_id'];
 							$curTitle['shortId'] = $modsForCopy['doc_id'];

--- a/code/web/release_notes/24.04.00.MD
+++ b/code/web/release_notes/24.04.00.MD
@@ -52,6 +52,7 @@
 ### Evergreen Updates
 - When updating from unapi, check the holdable attribute for the copy and if it is set to false set the subfield x to unholdable. (Ticket 126257) (*MDN*)
 - When indexing MARC records, mark any item with subfield x of unholdable as not holdable within Aspen. (Ticket 126257) (*MDN*)
+- When importing lists, check to see if 'doc_id' value is an integer and convert to string if necessary (*KL*)
 
 ### Hold Updates
 - Correct setting Always Use Pickup Location and desired pickup location after placing a hold. (Tickets 119902, 122172, 122199, 122719, 124389, 124902, 126808, 129215, 129312, 129316) (*MDN*)

--- a/code/web/sys/LibraryLocation/Library.php
+++ b/code/web/sys/LibraryLocation/Library.php
@@ -180,6 +180,7 @@ class Library extends DataObject {
 	public $selfRegistrationPasswordNotes;
 	public $selfRegistrationUrl;
 	public $selfRegistrationLocationRestrictions;
+	public $institutionCode;
 
 	public $enableCardRenewal;
 	public $showCardRenewalWhenExpirationIsClose;


### PR DESCRIPTION
declare $institutionCode
Fix issue for Evergreen driver when doc_id is an integer and we can't read it since we need a string value 
Updated release notes